### PR TITLE
💄CLI interface improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,5 @@ cython_debug/
 
 
 # Project specific files
-
+*.json
+*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,4 @@ cython_debug/
 
 
 # Project specific files
-*.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,4 @@ cython_debug/
 
 
 # Project specific files
-benchmark_report.json
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ cython_debug/
 
 # MacOS files
 .DS_Store
+
+
+# Project specific files
+benchmark_report.json

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -231,7 +231,7 @@ The project is fully configurable with environment variables. With that configur
 ## Contact and Support
 
 If you need help or have any questions, please open an issue on GitHub or contact us at support@neuralmagic.com.
-=======
+
 This will run automatic code styling using `black` and `isort` and test that the
 repository's code matches its standards.
 
@@ -263,4 +263,3 @@ settings = Settings()
 ```
 
 With that configuration set you can load parameters to `LoggingSettings()` by using environment variables. Just run `export GUIDELLM__LOGGING__DISABLED=true` or `export GUIDELLM__LOGGING__NESTED=another_value` respectfully. The nesting delimiter is `__`
->>>>>>> d8244f6 (📝 Project `configuration management` is documented)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -231,3 +231,36 @@ The project is fully configurable with environment variables. With that configur
 ## Contact and Support
 
 If you need help or have any questions, please open an issue on GitHub or contact us at support@neuralmagic.com.
+=======
+This will run automatic code styling using `black` and `isort` and test that the
+repository's code matches its standards.
+
+## Project configuration
+
+The project configuartion is powered by _[`🔗 pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)_
+
+The project configuration entrypoint is represented by lazy-loaded `settigns` singleton object ( `src/config/__init__` )
+
+The project is fully configurable with environment variables. All the default values and
+
+```py
+class NestedIntoLogging(BaseModel):
+    nested: str = "default value"
+
+class LoggingSettings(BaseModel):
+    # ...
+    disabled: bool = False
+
+
+class Settings(BaseSettings):
+    """The entrypoint to settings."""
+
+    # ...
+    logging: LoggingSettings = LoggingSettings()
+
+
+settings = Settings()
+```
+
+With that configuration set you can load parameters to `LoggingSettings()` by using environment variables. Just run `export GUIDELLM__LOGGING__DISABLED=true` or `export GUIDELLM__LOGGING__NESTED=another_value` respectfully. The nesting delimiter is `__`
+>>>>>>> d8244f6 (📝 Project `configuration management` is documented)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -228,12 +228,7 @@ The project is fully configurable with environment variables. With that configur
 | `GUIDELLM__OPENAI__BASE_URL`   | `http://localhost:8080` | The address to the **OpenAI-compatible** server.<br><br>OpenAI live base url is `https://api.openai.com/v1`                                             |
 | `GUIDELLM__OPENAI__API_KEY`    | `invalid`               | Corresponds to the **OpenAI-compatible** server API key.<br><br>If you look for the live key - check [this link](https://platform.openai.com/api-keys). |
 
-## Contact and Support
-
-If you need help or have any questions, please open an issue on GitHub or contact us at support@neuralmagic.com.
-
-This will run automatic code styling using `black` and `isort` and test that the
-repository's code matches its standards.
+<br>
 
 ## Project configuration
 
@@ -263,3 +258,7 @@ settings = Settings()
 ```
 
 With that configuration set you can load parameters to `LoggingSettings()` by using environment variables. Just run `export GUIDELLM__LOGGING__DISABLED=true` or `export GUIDELLM__LOGGING__NESTED=another_value` respectfully. The nesting delimiter is `__`
+
+## Contact and Support
+
+If you need help or have any questions, please open an issue on GitHub or contact us at support@neuralmagic.com.

--- a/examplemodel.yaml
+++ b/examplemodel.yaml
@@ -1,2 +1,0 @@
-age: 30
-name: John Doe

--- a/examplemodel.yaml
+++ b/examplemodel.yaml
@@ -1,0 +1,2 @@
+age: 30
+name: John Doe

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -23,6 +23,9 @@ class OpenAISettings(BaseModel):
     # NOTE: The default value is default address of llama.cpp http server
     base_url: str = "http://localhost:8080"
 
+    # The max value of generated tokens
+    max_gen_tokens: int = 4096
+
 
 class Settings(BaseSettings):
     """

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel
@@ -45,6 +46,8 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    root_dir: Path
+
     # TODO: add to the DEVELOPING.md after
     # https://github.com/neuralmagic/guidellm/pull/17
     # is merged
@@ -54,4 +57,7 @@ class Settings(BaseSettings):
     openai: OpenAISettings = OpenAISettings()
 
 
-settings = Settings()
+settings = Settings(
+    # NOTE: hardcoded since should not be changed in a runtime
+    root_dir=Path(__file__).parent.parent.parent,
+)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from pydantic import BaseModel
@@ -21,7 +20,7 @@ class OpenAISettings(BaseModel):
     api_key: str = "invalid"
 
     # OpenAI-compatible server URL
-    # NOTE: The default value is default address of llama.cpp web server
+    # NOTE: The default value is default address of llama.cpp http server
     base_url: str = "http://localhost:8080"
 
 
@@ -40,24 +39,14 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="GUIDELLM",
+        env_prefix="GUIDELLM__",
         env_nested_delimiter="__",
         env_file=".env",
         extra="ignore",
     )
 
-    root_dir: Path
-
-    # TODO: add to the DEVELOPING.md after
-    # https://github.com/neuralmagic/guidellm/pull/17
-    # is merged
-    debug: bool = False
-
     logging: LoggingSettings = LoggingSettings()
     openai: OpenAISettings = OpenAISettings()
 
 
-settings = Settings(
-    # NOTE: hardcoded since should not be changed in a runtime
-    root_dir=Path(__file__).parent.parent.parent,
-)
+settings = Settings()

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -45,6 +45,11 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    # TODO: add to the DEVELOPING.md after
+    # https://github.com/neuralmagic/guidellm/pull/17
+    # is merged
+    debug: bool = False
+
     logging: LoggingSettings = LoggingSettings()
     openai: OpenAISettings = OpenAISettings()
 

--- a/src/guidellm/__init__.py
+++ b/src/guidellm/__init__.py
@@ -2,3 +2,5 @@
 Guidellm is a package that provides an easy and intuitive interface for
 evaluating and benchmarking large language models (LLMs).
 """
+
+from .logger import configure_logger, logger  # noqa: F401

--- a/src/guidellm/__init__.py
+++ b/src/guidellm/__init__.py
@@ -2,7 +2,3 @@
 Guidellm is a package that provides an easy and intuitive interface for
 evaluating and benchmarking large language models (LLMs).
 """
-
-from .logger import configure_logger, logger
-
-__all__ = ["logger", "configure_logger"]

--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -1,6 +1,7 @@
 import functools
 from typing import Any, Dict, Generator, List, Optional
 
+import openai
 from loguru import logger
 from openai import OpenAI, Stream
 from openai.types import Completion
@@ -128,12 +129,19 @@ class OpenAIBackend(Backend):
         :rtype: List[str]
         """
 
-        models: List[str] = [
-            model.id for model in self.openai_client.models.list().data
-        ]
-        logger.info(f"Available models: {models}")
-
-        return models
+        try:
+            models: List[str] = [
+                model.id for model in self.openai_client.models.list().data
+            ]
+            logger.info(f"Available models: {models}")
+        except openai.NotFoundError as error:
+            logger.error(error)
+            if settings.debug is True:
+                return ["gpt-4o"]
+            else:
+                raise error
+        else:
+            return models
 
     @property
     @functools.lru_cache(maxsize=1)

--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -93,7 +93,12 @@ class OpenAIBackend(Backend):
         request_args: Dict = {"n": 1}
 
         if (num_gen_tokens := request.params.get("generated_tokens", None)) is not None:
-            request_args.update(max_tokens=num_gen_tokens, stop=None)
+            request_args.update(
+                {
+                    "max_tokens": num_gen_tokens,
+                    "stop": None,
+                }
+            )
 
         if self.request_args:
             request_args.update(self.request_args)
@@ -124,8 +129,6 @@ class OpenAIBackend(Backend):
                     ),
                 )
             else:
-                # FIX: This task work for infinite
-                print(f"🟢 generative Response adding token: [{chunk_content}]")
                 logger.debug("Received token from OpenAI backend")
                 yield GenerativeResponse(type_="token_iter", add_token=chunk_content)
 

--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -124,6 +124,8 @@ class OpenAIBackend(Backend):
                     ),
                 )
             else:
+                # FIX: This task work for infinite
+                print(f"🟢 generative Response adding token: [{chunk_content}]")
                 logger.debug("Received token from OpenAI backend")
                 yield GenerativeResponse(type_="token_iter", add_token=chunk_content)
 

--- a/src/guidellm/core/__init__.py
+++ b/src/guidellm/core/__init__.py
@@ -8,7 +8,7 @@ from .result import (
     TextGenerationError,
     TextGenerationResult,
 )
-from .serializable import Serializable, SerializableFileExtensions
+from .serializable import Serializable
 
 __all__ = [
     "Distribution",
@@ -19,6 +19,5 @@ __all__ = [
     "TextGenerationBenchmarkReport",
     "RequestConcurrencyMeasurement",
     "Serializable",
-    "SerializableFileExtensions",
     "GuidanceReport",
 ]

--- a/src/guidellm/core/__init__.py
+++ b/src/guidellm/core/__init__.py
@@ -8,7 +8,7 @@ from .result import (
     TextGenerationError,
     TextGenerationResult,
 )
-from .serializable import Serializable, SerializableFileType
+from .serializable import Serializable, SerializableFileExtensions
 
 __all__ = [
     "Distribution",
@@ -19,6 +19,6 @@ __all__ = [
     "TextGenerationBenchmarkReport",
     "RequestConcurrencyMeasurement",
     "Serializable",
-    "SerializableFileType",
+    "SerializableFileExtensions",
     "GuidanceReport",
 ]

--- a/src/guidellm/core/report.py
+++ b/src/guidellm/core/report.py
@@ -2,8 +2,8 @@ from typing import List
 
 from pydantic import Field
 
-from guidellm.core.serializable import Serializable
 from guidellm.core.result import TextGenerationBenchmarkReport
+from guidellm.core.serializable import Serializable
 
 __all__ = [
     "GuidanceReport",

--- a/src/guidellm/core/serializable.py
+++ b/src/guidellm/core/serializable.py
@@ -168,7 +168,7 @@ class Serializable(BaseModel):
         elif not os.path.isfile(path):
             raise ValueError(f"Path is not a file: {path}")
 
-        extension = path.split(".")[-1].upper()
+        extension = path.split(".")[-1].lower()
 
         if extension not in cls.available_file_extensions():
             raise ValueError(
@@ -177,16 +177,14 @@ class Serializable(BaseModel):
                 f"for {path}"
             )
 
-        type_ = SerializableFileExtensions[extension]
-
         with open(path, "r") as file:
             data = file.read()
 
-            if type_ == SerializableFileExtensions.YAML:
+            if extension == SerializableFileExtensions.YAML:
                 obj = cls.from_yaml(data)
-            elif type_ == SerializableFileExtensions.JSON:
+            elif extension == SerializableFileExtensions.JSON:
                 obj = cls.from_json(data)
             else:
-                raise ValueError(f"Unsupported file format: {type_}")
+                raise ValueError(f"Unsupported file format: {extension}")
 
         return obj

--- a/src/guidellm/core/serializable.py
+++ b/src/guidellm/core/serializable.py
@@ -125,7 +125,7 @@ class Serializable(BaseModel):
         return path
 
     @classmethod
-    def load_file(cls, path: str) -> "Serializable":
+    def load_file(cls, path: str):
         """
         Load a model from a file in either YAML or JSON format.
 

--- a/src/guidellm/executor/__init__.py
+++ b/src/guidellm/executor/__init__.py
@@ -1,17 +1,17 @@
 from .executor import Executor
 from .profile_generator import (
+    RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER,
+    RATE_TYPE_TO_PROFILE_MODE_MAPPER,
     FixedRateProfileGenerator,
     Profile,
     ProfileGenerationMode,
     ProfileGenerator,
     SweepProfileGenerator,
-    rate_type_to_load_gen_mode,
-    rate_type_to_profile_mode,
 )
 
 __all__ = [
-    "rate_type_to_load_gen_mode",
-    "rate_type_to_profile_mode",
+    "RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER",
+    "RATE_TYPE_TO_PROFILE_MODE_MAPPER",
     "Executor",
     "ProfileGenerationMode",
     "Profile",

--- a/src/guidellm/executor/profile_generator.py
+++ b/src/guidellm/executor/profile_generator.py
@@ -16,7 +16,7 @@ __all__ = [
     "SweepProfileGenerator",
 ]
 
-rate_type_to_load_gen_mode = {
+RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER = {
     "synchronous": LoadGenerationMode.SYNCHRONOUS,
     "constant": LoadGenerationMode.CONSTANT,
     "poisson": LoadGenerationMode.POISSON,
@@ -28,7 +28,7 @@ class ProfileGenerationMode(Enum):
     SWEEP = "sweep"
 
 
-rate_type_to_profile_mode = {
+RATE_TYPE_TO_PROFILE_MODE_MAPPER = {
     "synchronous": ProfileGenerationMode.FIXED_RATE,
     "constant": ProfileGenerationMode.FIXED_RATE,
     "poisson": ProfileGenerationMode.FIXED_RATE,
@@ -80,6 +80,7 @@ class FixedRateProfileGenerator(ProfileGenerator):
         super().__init__(ProfileGenerationMode.FIXED_RATE)
         if load_gen_mode == LoadGenerationMode.SYNCHRONOUS and rates and len(rates) > 0:
             raise ValueError("custom rates are not supported in synchronous mode")
+
         self._rates: Optional[List[float]] = rates
         self._load_gen_mode = load_gen_mode
         self._generated: bool = False

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -26,7 +26,6 @@ from guidellm.request.base import RequestGenerator
 )
 @click.option("--host", type=str, default=None, help="Host for benchmarking")
 @click.option("--port", type=str, default=None, help="Port for benchmarking")
-@click.option("--path", type=str, default=None, help="Path for benchmarking")
 @click.option(
     "--backend",
     type=click.Choice(["test", "openai_server"]),
@@ -82,7 +81,6 @@ def main(
     target,
     host,
     port,
-    path,
     backend,
     model,
     task,
@@ -102,7 +100,6 @@ def main(
         target=target,
         host=host,
         port=port,
-        path=path,
         model=model,
     )
 

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -1,11 +1,12 @@
 import click
+from loguru import logger
 
 from guidellm.backend import Backend
 from guidellm.core import GuidanceReport
 from guidellm.executor import (
+    RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER,
+    RATE_TYPE_TO_PROFILE_MODE_MAPPER,
     Executor,
-    rate_type_to_load_gen_mode,
-    rate_type_to_profile_mode,
 )
 from guidellm.logger import configure_logger
 from guidellm.request import (
@@ -20,7 +21,7 @@ from guidellm.request.base import RequestGenerator
 @click.option(
     "--target",
     type=str,
-    default="localhost:8000/completions",
+    default="http://localhost:8000",
     help="Target for benchmarking",
 )
 @click.option("--host", type=str, default=None, help="Host for benchmarking")
@@ -55,18 +56,18 @@ from guidellm.request.base import RequestGenerator
 @click.option(
     "--rate",
     type=float,
-    default=[1.0],
+    default=None,
     help="Rate to use for constant and poisson rate types",
     multiple=True,
 )
 @click.option(
-    "--num-seconds",
+    "--max-seconds",
     type=int,
     default=120,
     help="Number of seconds to result each request rate at",
 )
 @click.option(
-    "--num-requests",
+    "--max-requests",
     type=int,
     default=None,
     help="Number of requests to send for each rate",
@@ -90,13 +91,13 @@ def main(
     tokenizer,
     rate_type,
     rate,
-    num_seconds,
-    num_requests,
+    max_seconds,
+    max_requests,
     output_path,
 ):
 
     # Create backend
-    Backend.create(
+    _backend = Backend.create(
         backend_type=backend,
         target=target,
         host=host,
@@ -125,19 +126,23 @@ def main(
     else:
         raise ValueError(f"Unknown data type: {data_type}")
 
-    profile_mode = rate_type_to_profile_mode.get(rate_type)
-    load_gen_mode = rate_type_to_load_gen_mode.get(rate_type, None)
+    profile_mode = RATE_TYPE_TO_PROFILE_MODE_MAPPER.get(rate_type)
+    load_gen_mode = RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER.get(rate_type)
+
     if not profile_mode or not load_gen_mode:
         raise ValueError("Invalid rate type")
+
     # Create executor
     executor = Executor(
         request_generator=request_generator,
-        backend=backend,
+        backend=_backend,
         profile_mode=profile_mode,
         profile_args={"load_gen_mode": load_gen_mode, "rates": rate},
-        max_requests=num_requests,
-        max_duration=num_seconds,
+        max_requests=max_requests,
+        max_duration=max_seconds,
     )
+
+    logger.debug("Running the executor")
     report = executor.run()
 
     # Save or print results

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -7,6 +7,7 @@ from guidellm.executor import (
     rate_type_to_load_gen_mode,
     rate_type_to_profile_mode,
 )
+from guidellm.logger import configure_logger
 from guidellm.request import (
     EmulatedRequestGenerator,
     FileRequestGenerator,
@@ -143,4 +144,9 @@ def main(
 
 
 if __name__ == "__main__":
+    # invoke logger setup on import with default values
+    # enabling console logging with INFO and disabling file logging
+    configure_logger()
+
+    # entrypoint
     main()

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -23,15 +23,20 @@ from guidellm.request.base import RequestGenerator
     default="localhost:8000/completions",
     help="Target for benchmarking",
 )
-@click.option("--host", type=str, help="Host for benchmarking")
-@click.option("--port", type=str, help="Port for benchmarking")
-@click.option("--path", type=str, help="Path for benchmarking")
+@click.option("--host", type=str, default=None, help="Host for benchmarking")
+@click.option("--port", type=str, default=None, help="Port for benchmarking")
+@click.option("--path", type=str, default=None, help="Path for benchmarking")
 @click.option(
-    "--backend", type=str, default="openai_server", help="Backend type for benchmarking"
+    "--backend",
+    type=click.Choice(["test", "openai_server"]),
+    default="openai_server",
+    help="Backend type for benchmarking",
 )
 @click.option("--model", type=str, default=None, help="Model to use for benchmarking")
 @click.option("--task", type=str, default=None, help="Task to use for benchmarking")
-@click.option("--data", type=str, help="Data file or alias for benchmarking")
+@click.option(
+    "--data", type=str, default=None, help="Data file or alias for benchmarking"
+)
 @click.option(
     "--data-type",
     type=click.Choice(["emulated", "file", "transformers"]),
@@ -44,7 +49,7 @@ from guidellm.request.base import RequestGenerator
 @click.option(
     "--rate-type",
     type=click.Choice(["sweep", "synchronous", "constant", "poisson"]),
-    default="sweep",
+    default="synchronous",
     help="Type of rate generation for benchmarking",
 )
 @click.option(
@@ -57,7 +62,7 @@ from guidellm.request.base import RequestGenerator
 @click.option(
     "--num-seconds",
     type=int,
-    default="120",
+    default=120,
     help="Number of seconds to result each request rate at",
 )
 @click.option(
@@ -89,6 +94,7 @@ def main(
     num_requests,
     output_path,
 ):
+
     # Create backend
     Backend.create(
         backend_type=backend,

--- a/src/guidellm/request/base.py
+++ b/src/guidellm/request/base.py
@@ -146,9 +146,6 @@ class RequestGenerator(ABC):
                 if self._queue.qsize() < self._async_queue_size:
                     item = self.create_item()
                     self._queue.put(item, timeout=0.1)
-                    # print(
-                    #     f"[TMP_LOG>] Item is added to the queue. Current size: {self._queue.qsize()}"
-                    # )  # TODO: remove
                     logger.debug(
                         "Item added to queue. Current queue size: {}",
                         self._queue.qsize(),

--- a/src/guidellm/request/base.py
+++ b/src/guidellm/request/base.py
@@ -146,6 +146,9 @@ class RequestGenerator(ABC):
                 if self._queue.qsize() < self._async_queue_size:
                     item = self.create_item()
                     self._queue.put(item, timeout=0.1)
+                    # print(
+                    #     f"[TMP_LOG>] Item is added to the queue. Current size: {self._queue.qsize()}"
+                    # )  # TODO: remove
                     logger.debug(
                         "Item added to queue. Current queue size: {}",
                         self._queue.qsize(),

--- a/src/guidellm/request/base.py
+++ b/src/guidellm/request/base.py
@@ -140,6 +140,7 @@ class RequestGenerator(ABC):
         """
         Populate the request queue in the background.
         """
+
         while not self._stop_event.is_set():
             with contextlib.suppress(Full):
                 if self._queue.qsize() < self._async_queue_size:

--- a/src/guidellm/request/transformers.py
+++ b/src/guidellm/request/transformers.py
@@ -124,7 +124,11 @@ class TransformersDatasetRequestGenerator(RequestGenerator):
         token_count = (
             self._tokenizer(prompt)["input_ids"].shape[0] if self._tokenizer else None
         )
-        request = TextGenerationRequest(prompt=prompt, prompt_token_count=token_count)
+        request = TextGenerationRequest(
+            prompt=prompt,
+            prompt_token_count=token_count,
+            params={"generated_tokens": 10},  # TODO: remove
+        )
         logger.debug(f"Created new TextGenerationRequest: {request}")
 
         return request

--- a/src/guidellm/request/transformers.py
+++ b/src/guidellm/request/transformers.py
@@ -127,7 +127,6 @@ class TransformersDatasetRequestGenerator(RequestGenerator):
         request = TextGenerationRequest(
             prompt=prompt,
             prompt_token_count=token_count,
-            params={"generated_tokens": 10},  # TODO: remove
         )
         logger.debug(f"Created new TextGenerationRequest: {request}")
 

--- a/src/guidellm/request/transformers.py
+++ b/src/guidellm/request/transformers.py
@@ -41,13 +41,16 @@ class TransformersDatasetRequestGenerator(RequestGenerator):
         async_queue_size: int = 50,
         **kwargs,
     ):
-        super().__init__(tokenizer, mode, async_queue_size)
         self._dataset = dataset
         self._split = split
         self._column = column
         self._kwargs = kwargs
         self._hf_dataset = self._load_dataset()
         self._iterator = iter(self._hf_dataset)
+
+        # NOTE: Must be after all the parameters since the queue population
+        #       function requires attributes above
+        super().__init__(tokenizer, mode, async_queue_size)
 
     def _load_dataset(self):
         """
@@ -106,10 +109,16 @@ class TransformersDatasetRequestGenerator(RequestGenerator):
         :rtype: TextGenerationRequest
         """
         try:
-            data = next(self._iterator)
-        except StopIteration:
+            getattr(self, "_hf_dataset")
+        except AttributeError:
+            self._hf_dataset = self._load_dataset()
+
+        try:
+            getattr(self, "_iterator")
+        except (StopIteration, AttributeError):
             self._iterator = iter(self._hf_dataset)
-            data = next(self._iterator)
+
+        data = next(self._iterator)
 
         prompt = data[self._column] if self._column in data else str(data)
         token_count = (

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -99,6 +99,8 @@ class Scheduler:
         start_time = time.time()
         requests_counter = 0
 
+        logger.debug("Running scheduler in sync mode")
+
         for callback in self._sync_tasks():
             if (
                 self._max_requests is not None
@@ -142,6 +144,8 @@ class Scheduler:
             tasks.append((request, task))
             requests_counter += 1
 
+            print("Task started")
+
             if (
                 self._max_duration is not None
                 and time.time() - start_time >= self._max_duration
@@ -166,7 +170,7 @@ class Scheduler:
                     asyncio.gather(*(t for _, t in tasks), return_exceptions=True),
                     self._max_duration,
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self._cancel_running_tasks(tasks=tasks, benchmark=benchmark)
 
         return benchmark

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -205,6 +205,7 @@ class Scheduler:
                 None, functools.partial(self._backend.submit, request=request)
             )
         except Exception as error:
+            logger.error(error)
             benchmark.errors.append(
                 TextGenerationError(
                     request=request, message=str(asyncio.CancelledError())

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -144,8 +144,6 @@ class Scheduler:
             tasks.append((request, task))
             requests_counter += 1
 
-            print("Task started")
-
             if (
                 self._max_duration is not None
                 and time.time() - start_time >= self._max_duration
@@ -206,7 +204,7 @@ class Scheduler:
             res = await self._event_loop.run_in_executor(
                 None, functools.partial(self._backend.submit, request=request)
             )
-        except Exception:
+        except Exception as error:
             benchmark.errors.append(
                 TextGenerationError(
                     request=request, message=str(asyncio.CancelledError())

--- a/src/guidellm/utils/__init__.py
+++ b/src/guidellm/utils/__init__.py
@@ -3,7 +3,7 @@ from .constants import (
     PREFERRED_DATA_SPLITS,
     STANDARD_SLEEP_INTERVAL,
 )
-from .functions import is_file_name, is_directory_name
+from .functions import is_directory_name, is_file_name
 
 __all__ = [
     "PREFERRED_DATA_COLUMNS",

--- a/src/guidellm/utils/functions.py
+++ b/src/guidellm/utils/functions.py
@@ -1,6 +1,5 @@
 import os
 
-
 __all__ = [
     "is_file_name",
     "is_directory_name",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def openai_backend_factory() -> Callable[..., OpenAIBackend]:
         defaults = {
             "backend_type": BackendEngine.OPENAI_SERVER,
             "openai_api_key": "required but not used",
-            "internal_callback_url": base_url or settings.openai.base_url,
+            "target": base_url or settings.openai.base_url,
         }
 
         defaults.update(kwargs)

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def patch_main(mocker) -> MagicMock:
+    return mocker.patch("guidellm.main.main.callback")
+
+
+@pytest.fixture
+def default_main_kwargs() -> Dict[str, Any]:
+    """
+    All the defaults come from the `guidellm.main` function.
+    """
+
+    return {
+        "target": "localhost:8000/completions",
+        "host": None,
+        "port": None,
+        "path": None,
+        "backend": "openai_server",
+        "model": None,
+        "task": None,
+        "data": None,
+        "data_type": "transformers",
+        "tokenizer": None,
+        "rate_type": "synchronous",
+        "rate": (1.0,),
+        "num_seconds": 120,
+        "num_requests": None,
+    }

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -22,7 +22,7 @@ def default_main_kwargs() -> Dict[str, Any]:
     """
 
     return {
-        "target": "localhost:8000/completions",
+        "target": "http://localhost:8000",
         "host": None,
         "port": None,
         "path": None,
@@ -33,7 +33,8 @@ def default_main_kwargs() -> Dict[str, Any]:
         "data_type": "transformers",
         "tokenizer": None,
         "rate_type": "synchronous",
-        "rate": (1.0,),
-        "num_seconds": 120,
-        "num_requests": None,
+        "rate": (),
+        "max_seconds": 120,
+        "max_requests": None,
+        "output_path": "benchmark_report.json",
     }

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -25,7 +25,6 @@ def default_main_kwargs() -> Dict[str, Any]:
         "target": "http://localhost:8000",
         "host": None,
         "port": None,
-        "path": None,
         "backend": "openai_server",
         "model": None,
         "task": None,

--- a/tests/unit/cli/test_application_entrypoint.py
+++ b/tests/unit/cli/test_application_entrypoint.py
@@ -43,10 +43,10 @@ def test_main_cli_overrided(
             ),
         ),
         (
-            ["--num-requests", "str instead of int"],
+            ["--max-requests", "str instead of int"],
             (
                 b"Usage: main [OPTIONS]\nTry 'main --help' for help.\n\n"
-                b"Error: Invalid value for '--num-requests': "
+                b"Error: Invalid value for '--max-requests': "
                 b"'str instead of int' is not a valid integer.\n"
             ),
         ),

--- a/tests/unit/cli/test_application_entrypoint.py
+++ b/tests/unit/cli/test_application_entrypoint.py
@@ -1,0 +1,64 @@
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from guidellm.main import main
+
+
+def test_main_defaults_from_cli(
+    patch_main: MagicMock, cli_runner: CliRunner, default_main_kwargs
+):
+    cli_runner.invoke(main)
+
+    assert patch_main.call_count == 1
+    assert patch_main.call_args.kwargs == default_main_kwargs
+
+
+def test_main_cli_overrided(
+    patch_main: MagicMock, cli_runner: CliRunner, default_main_kwargs
+):
+    cli_runner.invoke(
+        main,
+        ["--target", "localhost:9000", "--backend", "test", "--rate-type", "sweep"],
+    )
+    default_main_kwargs.update(
+        {"target": "localhost:9000", "backend": "test", "rate_type": "sweep"}
+    )
+
+    assert patch_main.call_count == 1
+    assert patch_main.call_args.kwargs == default_main_kwargs
+
+
+@pytest.mark.parametrize(
+    "args,expected_stdout",
+    [
+        (
+            ["--backend", "invalid", "--rate-type", "sweep"],
+            (
+                b"Usage: main [OPTIONS]\nTry 'main --help' for help.\n\n"
+                b"Error: Invalid value for '--backend': "
+                b"'invalid' is not one of 'test', 'openai_server'.\n"
+            ),
+        ),
+        (
+            ["--num-requests", "str instead of int"],
+            (
+                b"Usage: main [OPTIONS]\nTry 'main --help' for help.\n\n"
+                b"Error: Invalid value for '--num-requests': "
+                b"'str instead of int' is not a valid integer.\n"
+            ),
+        ),
+    ],
+)
+def test_main_cli_validation_error(
+    patch_main: MagicMock,
+    cli_runner: CliRunner,
+    args: List[str],
+    expected_stdout: bytes,
+):
+    result = cli_runner.invoke(main, args)
+
+    assert patch_main.call_count == 0
+    assert result.stdout_bytes == expected_stdout

--- a/tests/unit/cli/test_main_validation.py
+++ b/tests/unit/cli/test_main_validation.py
@@ -1,0 +1,37 @@
+import pytest
+
+from guidellm.main import main
+
+
+def test_task_without_data(mocker, default_main_kwargs):
+    patch = mocker.patch("guidellm.backend.Backend.create")
+    default_main_kwargs.update({"task": "can't be used without data"})
+    with pytest.raises(NotImplementedError):
+        getattr(main, "callback")(**default_main_kwargs)
+
+    assert patch.call_count == 1
+
+
+def test_invalid_data_type(mocker, default_main_kwargs):
+    patch = mocker.patch("guidellm.backend.Backend.create")
+    default_main_kwargs.update({"data_type": "invalid"})
+
+    with pytest.raises(ValueError):
+        getattr(main, "callback")(**default_main_kwargs)
+
+    assert patch.call_count == 1
+
+
+def test_invalid_rate_type(mocker, default_main_kwargs):
+    patch = mocker.patch("guidellm.backend.Backend.create")
+    file_request_generator_initialization_patch = mocker.patch(
+        "guidellm.request.file.FileRequestGenerator.__init__",
+        return_value=None,
+    )
+    default_main_kwargs.update({"rate_type": "invalid", "data_type": "file"})
+
+    with pytest.raises(ValueError):
+        getattr(main, "callback")(**default_main_kwargs)
+
+    assert patch.call_count == 1
+    assert file_request_generator_initialization_patch.call_count == 1

--- a/tests/unit/core/test_report.py
+++ b/tests/unit/core/test_report.py
@@ -1,14 +1,16 @@
-import pytest
 import os
 import tempfile
+
+import pytest
+
 from guidellm.core import (
-    TextGenerationBenchmark,
-    TextGenerationBenchmarkReport,
-    TextGenerationResult,
-    TextGenerationRequest,
-    TextGenerationError,
     Distribution,
     GuidanceReport,
+    TextGenerationBenchmark,
+    TextGenerationBenchmarkReport,
+    TextGenerationError,
+    TextGenerationRequest,
+    TextGenerationResult,
 )
 
 

--- a/tests/unit/core/test_serializable.py
+++ b/tests/unit/core/test_serializable.py
@@ -118,7 +118,7 @@ def test_serializable_load_file_invalid_extension():
         invalid_file_path = os.path.join(temp_dir, "example.txt")
         with open(invalid_file_path, "w") as file:
             file.write("invalid content")
-        with pytest.raises(ValueError, match="Unsupported file extension: TXT"):
+        with pytest.raises(ValueError, match="Unsupported file extension: txt"):
             ExampleModel.load_file(invalid_file_path)
 
 

--- a/tests/unit/core/test_serializable.py
+++ b/tests/unit/core/test_serializable.py
@@ -126,8 +126,7 @@ def test_serializable_load_file_invalid_extension():
 def test_serializable_file_no_type_provided():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        file_path = os.path.join(temp_dir, "example")
-        saved_path = example.save_file(file_path)
+        saved_path = example.save_file(temp_dir)
         assert os.path.exists(saved_path)
         assert saved_path.endswith(".yaml")
         loaded_example = ExampleModel.load_file(saved_path)

--- a/tests/unit/core/test_serializable.py
+++ b/tests/unit/core/test_serializable.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from guidellm.core.serializable import Serializable, SerializableFileExtensions
+from guidellm.core.serializable import Serializable
 
 
 class ExampleModel(Serializable):
@@ -48,7 +48,7 @@ def test_serializable_file_json():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = os.path.join(temp_dir, "example.json")
-        saved_path = example.save_file(file_path, SerializableFileExtensions.JSON)
+        saved_path = example.save_file(file_path, "json")
         assert os.path.exists(saved_path)
         loaded_example = ExampleModel.load_file(saved_path)
         assert loaded_example.name == "John Doe"
@@ -60,7 +60,7 @@ def test_serializable_file_yaml():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = os.path.join(temp_dir, "example.yaml")
-        saved_path = example.save_file(file_path, SerializableFileExtensions.YAML)
+        saved_path = example.save_file(file_path, "yaml")
         assert os.path.exists(saved_path)
         loaded_example = ExampleModel.load_file(saved_path)
         assert loaded_example.name == "John Doe"
@@ -83,7 +83,7 @@ def test_serializable_file_without_extension():
 def test_serializable_file_with_directory_json():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        saved_path = example.save_file(temp_dir, SerializableFileExtensions.JSON)
+        saved_path = example.save_file(temp_dir, "json")
         assert os.path.exists(saved_path)
         assert saved_path.endswith(".json")
         loaded_example = ExampleModel.load_file(saved_path)
@@ -95,7 +95,7 @@ def test_serializable_file_with_directory_json():
 def test_serializable_file_with_directory_yaml():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        saved_path = example.save_file(temp_dir, SerializableFileExtensions.YAML)
+        saved_path = example.save_file(temp_dir, "yaml")
         assert os.path.exists(saved_path)
         assert saved_path.endswith(".yaml")
         loaded_example = ExampleModel.load_file(saved_path)
@@ -138,7 +138,7 @@ def test_serializable_file_no_type_provided():
 def test_serializable_file_infer_extension():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        inferred_path = example.save_file(temp_dir, SerializableFileExtensions.JSON)
+        inferred_path = example.save_file(temp_dir, "json")
         assert os.path.exists(inferred_path)
         assert inferred_path.endswith(".json")
         loaded_example = ExampleModel.load_file(inferred_path)

--- a/tests/unit/core/test_serializable.py
+++ b/tests/unit/core/test_serializable.py
@@ -1,7 +1,9 @@
 import os
 import tempfile
+
 import pytest
-from guidellm.core.serializable import Serializable, SerializableFileType
+
+from guidellm.core.serializable import Serializable, SerializableFileExtensions
 
 
 class ExampleModel(Serializable):
@@ -46,7 +48,7 @@ def test_serializable_file_json():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = os.path.join(temp_dir, "example.json")
-        saved_path = example.save_file(file_path, SerializableFileType.JSON)
+        saved_path = example.save_file(file_path, SerializableFileExtensions.JSON)
         assert os.path.exists(saved_path)
         loaded_example = ExampleModel.load_file(saved_path)
         assert loaded_example.name == "John Doe"
@@ -58,7 +60,7 @@ def test_serializable_file_yaml():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = os.path.join(temp_dir, "example.yaml")
-        saved_path = example.save_file(file_path, SerializableFileType.YAML)
+        saved_path = example.save_file(file_path, SerializableFileExtensions.YAML)
         assert os.path.exists(saved_path)
         loaded_example = ExampleModel.load_file(saved_path)
         assert loaded_example.name == "John Doe"
@@ -81,7 +83,7 @@ def test_serializable_file_without_extension():
 def test_serializable_file_with_directory_json():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        saved_path = example.save_file(temp_dir, SerializableFileType.JSON)
+        saved_path = example.save_file(temp_dir, SerializableFileExtensions.JSON)
         assert os.path.exists(saved_path)
         assert saved_path.endswith(".json")
         loaded_example = ExampleModel.load_file(saved_path)
@@ -93,7 +95,7 @@ def test_serializable_file_with_directory_json():
 def test_serializable_file_with_directory_yaml():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        saved_path = example.save_file(temp_dir, SerializableFileType.YAML)
+        saved_path = example.save_file(temp_dir, SerializableFileExtensions.YAML)
         assert os.path.exists(saved_path)
         assert saved_path.endswith(".yaml")
         loaded_example = ExampleModel.load_file(saved_path)
@@ -137,7 +139,7 @@ def test_serializable_file_no_type_provided():
 def test_serializable_file_infer_extension():
     example = ExampleModel(name="John Doe", age=30)
     with tempfile.TemporaryDirectory() as temp_dir:
-        inferred_path = example.save_file(temp_dir, SerializableFileType.JSON)
+        inferred_path = example.save_file(temp_dir, SerializableFileExtensions.JSON)
         assert os.path.exists(inferred_path)
         assert inferred_path.endswith(".json")
         loaded_example = ExampleModel.load_file(inferred_path)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -14,7 +14,7 @@ def reset_logger():
 
 
 def test_default_logger_settings(capsys):
-    configure_logger()
+    configure_logger(config=LoggingSettings())
 
     # Default settings should log to console with INFO level and no file logging
     logger.info("Info message")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,7 +1,8 @@
 import pytest
+from loguru import logger
 
 from config import LoggingSettings
-from guidellm import configure_logger, logger
+from guidellm.logger import configure_logger
 
 
 @pytest.fixture(autouse=True)

--- a/utils/inject_build_props.py
+++ b/utils/inject_build_props.py
@@ -1,8 +1,9 @@
-from loguru import logger
-import toml
 import os
-from datetime import datetime
 import re
+from datetime import datetime
+
+import toml
+from loguru import logger
 
 
 def get_build_type():


### PR DESCRIPTION
# Summary

- The `click` CLI interface is tested with a bunch of unit tests
- The `main` function validation is added.
- `OpenAIBackend` initializer parameters are optimized
    - target, host, and port parameters usage is simplified
- `openai.NotFound` **_available models_** error is handled
- `SerializableFileType` renamed to `SerializableFileExtension`
- `SerializableFileExtension` now inherits `str` to simplify usage, since this Enum class is mostly used to work with strings.
- `rate_type_to_load_gen_mode` renamed to `RATE_TYPE_TO_LOAD_GEN_MODE_MAPPER`
- `rate_type_to_profile_mode` renamed to `RATE_TYPE_TO_PROFILE_MODE_MAPPER`
- CLI parameters are renamed:
    - `--num-seconds` -> `--max-seconds`
    - `--num-requests` -> `--max-requests`
- `path` removed from CLI arguments since it is not used
- .env `GUIDELLM` prefix is fixed
- Unused comments, settings, and code are removed
- Logger default unit test uses the injected logging settings object
- Module `backend.openai` has `_base_url` renamed to the `base_url`
- In `OpenAIBackend.make_request`, the `GenerativeResponse` always counts `output_tokens` with `self._token_count`
- `SerializableFileExtensions` is replaced with pure Python strings