### PR TITLE
Add pre-commit checks to quality workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -44,3 +44,16 @@ jobs:
         run: pip install tox
       - name: Run type checks
         run: tox -e types
+
+  precommit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
         loguru,
         numpy,
         pydantic,
+        pydantic_settings,
         pyyaml,
         openai,
         requests,


### PR DESCRIPTION
## Summary

Enhances our CI/CD pipeline by introducing pre-commit checks to the quality workflows. This ensures pre-check standards and requirements are enforced even if developers do not install pre-commit locally and won't break for others.

## Details

- Added a new job to the `.github/workflows/quality.yml` file that runs pre-commit checks.
- This job runs on `ubuntu-latest` and is configured to set up Python 3.8, install pre-commit, and run the pre-commit checks on all files.
- Ensures that code quality checks must pass before merging, improving code consistency and reducing errors.

## Test Plan

- Automated Testing: Verifying with this diff that the new github actions will pass