### PR TITLE
Add summary metrics to saved json file

### DIFF
--- a/src/guidellm/core/report.py
+++ b/src/guidellm/core/report.py
@@ -147,19 +147,15 @@ def _create_benchmark_report_data_tokens_summary(
     for benchmark in report.benchmarks_sorted:
         table.add_row(
             _benchmark_rate_id(benchmark),
-            f"{benchmark.prompt_token_distribution.mean:.2f}",
+            f"{benchmark.prompt_token:.2f}",
             ", ".join(
                 f"{percentile:.1f}"
-                for percentile in benchmark.prompt_token_distribution.percentiles(
-                    [1, 5, 50, 95, 99]
-                )
+                for percentile in benchmark.prompt_token_percentiles
             ),
-            f"{benchmark.output_token_distribution.mean:.2f}",
+            f"{benchmark.output_token:.2f}",
             ", ".join(
                 f"{percentile:.1f}"
-                for percentile in benchmark.output_token_distribution.percentiles(
-                    [1, 5, 50, 95, 99]
-                )
+                for percentile in benchmark.output_token_percentiles
             ),
         )
     logger.debug("Created data tokens summary table for the report.")
@@ -181,7 +177,7 @@ def _create_benchmark_report_dist_perf_summary(
         "Benchmark",
         "Request Latency [1%, 5%, 10%, 50%, 90%, 95%, 99%] (sec)",
         "Time to First Token [1%, 5%, 10%, 50%, 90%, 95%, 99%] (ms)",
-        "Inter Token Latency [1%, 5%, 10%, 50%, 90% 95%, 99%] (ms)",
+        "Inter Token Latency [1%, 5%, 10%, 50%, 90%, 95%, 99%] (ms)",
         title="[magenta]Performance Stats by Benchmark[/magenta]",
         title_style="bold",
         title_justify="left",
@@ -193,21 +189,15 @@ def _create_benchmark_report_dist_perf_summary(
             _benchmark_rate_id(benchmark),
             ", ".join(
                 f"{percentile:.2f}"
-                for percentile in benchmark.request_latency_distribution.percentiles(
-                    [1, 5, 10, 50, 90, 95, 99]
-                )
+                for percentile in benchmark.request_latency_percentiles
             ),
             ", ".join(
                 f"{percentile * 1000:.1f}"
-                for percentile in benchmark.ttft_distribution.percentiles(
-                    [1, 5, 10, 50, 90, 95, 99]
-                )
+                for percentile in benchmark.time_to_first_token_percentiles
             ),
             ", ".join(
                 f"{percentile * 1000:.1f}"
-                for percentile in benchmark.itl_distribution.percentiles(
-                    [1, 5, 10, 50, 90, 95, 99]
-                )
+                for percentile in benchmark.inter_token_latency_percentiles
             ),
         )
     logger.debug("Created distribution performance summary table for the report.")

--- a/src/guidellm/core/result.py
+++ b/src/guidellm/core/result.py
@@ -221,7 +221,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return iter(self.results)
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def request_count(self) -> int:
         """
@@ -232,7 +232,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return len(self.results)
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def error_count(self) -> int:
         """
@@ -243,7 +243,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return len(self.errors)
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def total_count(self) -> int:
         """
@@ -254,7 +254,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.request_count + self.error_count
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def start_time(self) -> Optional[float]:
         """
@@ -268,7 +268,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.results[0].start_time
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def end_time(self) -> Optional[float]:
         """
@@ -282,7 +282,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.results[-1].end_time
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def duration(self) -> float:
         """
@@ -296,7 +296,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.end_time - self.start_time
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def completed_request_rate(self) -> float:
         """
@@ -310,7 +310,7 @@ class TextGenerationBenchmark(Serializable):
 
         return len(self.results) / self.duration
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def request_latency(self) -> float:
         """
@@ -340,7 +340,7 @@ class TextGenerationBenchmark(Serializable):
             ]
         )
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def request_latency_percentiles(self) -> List[float]:
         """
@@ -352,7 +352,7 @@ class TextGenerationBenchmark(Serializable):
         return self.request_latency_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
 
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def time_to_first_token(self) -> float:
         """
@@ -382,7 +382,7 @@ class TextGenerationBenchmark(Serializable):
             ]
         )
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def time_to_first_token_percentiles(self) -> List[float]:
         """
@@ -395,7 +395,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.ttft_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def inter_token_latency(self) -> float:
         """
@@ -423,7 +423,7 @@ class TextGenerationBenchmark(Serializable):
             ]
         )
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def inter_token_latency_percentiles(self) -> List[float]:
         """
@@ -434,7 +434,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.itl_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def output_token_throughput(self) -> float:
         """
@@ -450,7 +450,7 @@ class TextGenerationBenchmark(Serializable):
 
         return total_tokens / self.duration
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def prompt_token(self) -> float:
         """
@@ -471,7 +471,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return Distribution(data=[result.prompt_token_count for result in self.results])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def prompt_token_percentiles(self) -> List[float]:
         """
@@ -482,7 +482,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.prompt_token_distribution.percentiles([1, 5, 50, 95, 99])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def output_token(self) -> float:
         """
@@ -503,7 +503,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return Distribution(data=[result.output_token_count for result in self.results])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def output_token_percentiles(self) -> List[float]:
         """
@@ -514,7 +514,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.output_token_distribution.percentiles([1, 5, 50, 95, 99])
 
-    @computed_field
+    @computed_field # type: ignore[misc]
     @property
     def overloaded(self) -> bool:
         if (

--- a/src/guidellm/core/result.py
+++ b/src/guidellm/core/result.py
@@ -2,7 +2,7 @@ from time import time
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from guidellm.core.distribution import Distribution
 from guidellm.core.request import TextGenerationRequest
@@ -221,6 +221,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return iter(self.results)
 
+    @computed_field
     @property
     def request_count(self) -> int:
         """
@@ -231,6 +232,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return len(self.results)
 
+    @computed_field
     @property
     def error_count(self) -> int:
         """
@@ -241,6 +243,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return len(self.errors)
 
+    @computed_field
     @property
     def total_count(self) -> int:
         """
@@ -251,6 +254,7 @@ class TextGenerationBenchmark(Serializable):
         """
         return self.request_count + self.error_count
 
+    @computed_field
     @property
     def start_time(self) -> Optional[float]:
         """
@@ -264,6 +268,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.results[0].start_time
 
+    @computed_field
     @property
     def end_time(self) -> Optional[float]:
         """
@@ -277,6 +282,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.results[-1].end_time
 
+    @computed_field
     @property
     def duration(self) -> float:
         """
@@ -290,6 +296,7 @@ class TextGenerationBenchmark(Serializable):
 
         return self.end_time - self.start_time
 
+    @computed_field
     @property
     def completed_request_rate(self) -> float:
         """
@@ -303,6 +310,7 @@ class TextGenerationBenchmark(Serializable):
 
         return len(self.results) / self.duration
 
+    @computed_field
     @property
     def request_latency(self) -> float:
         """
@@ -332,6 +340,19 @@ class TextGenerationBenchmark(Serializable):
             ]
         )
 
+    @computed_field
+    @property
+    def request_latency_percentiles(self) -> List[float]:
+        """
+        Get standard percentiles of request latency in seconds.
+
+        :return: List of percentile request latency in seconds
+        :rtype: List[float]
+        """
+        return self.request_latency_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
+
+
+    @computed_field
     @property
     def time_to_first_token(self) -> float:
         """
@@ -360,7 +381,19 @@ class TextGenerationBenchmark(Serializable):
                 if result.first_token_time is not None
             ]
         )
+    
+    @computed_field
+    @property
+    def time_to_first_token_percentiles(self) -> List[float]:
+        """
+        Get standard percentiles for time taken to decode the first token in milliseconds.
 
+        :return: List of percentile time taken to decode the first token in milliseconds.
+        :rtype: List[float]
+        """        
+        return self.ttft_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
+
+    @computed_field
     @property
     def inter_token_latency(self) -> float:
         """
@@ -387,7 +420,19 @@ class TextGenerationBenchmark(Serializable):
                 decode for result in self.results for decode in result.decode_times.data
             ]
         )
+    
+    @computed_field
+    @property
+    def inter_token_latency_percentiles(self) -> List[float]:
+        """
+        Get standard percentiles for the time between tokens in milliseconds.
 
+        :return: List of percentiles for the average time between tokens.
+        :rtype: List[float]
+        """
+        return self.itl_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
+
+    @computed_field
     @property
     def output_token_throughput(self) -> float:
         """
@@ -403,6 +448,17 @@ class TextGenerationBenchmark(Serializable):
 
         return total_tokens / self.duration
 
+    @computed_field
+    @property
+    def prompt_token(self) -> float:
+        """
+        Get the average number of prompt tokens.
+
+        :return: The average number of prompt tokens.
+        :rtype: float
+        """
+        return self.prompt_token_distribution.mean
+
     @property
     def prompt_token_distribution(self) -> Distribution:
         """
@@ -412,6 +468,28 @@ class TextGenerationBenchmark(Serializable):
         :rtype: Distribution
         """
         return Distribution(data=[result.prompt_token_count for result in self.results])
+
+    @computed_field
+    @property
+    def prompt_token_percentiles(self) -> List[float]:
+        """
+        Get standard percentiles for number of prompt tokens.
+
+        :return: List of percentiles of number of prompt tokens.
+        :rtype: List[float]
+        """
+        return self.prompt_token_distribution.percentiles([1, 5, 50, 95, 99])
+
+    @computed_field
+    @property
+    def output_token(self) -> float:
+        """
+        Get the average number of output tokens.
+
+        :return: The average number of output tokens.
+        :rtype: float
+        """
+        return self.output_token_distribution.mean
 
     @property
     def output_token_distribution(self) -> Distribution:
@@ -423,6 +501,18 @@ class TextGenerationBenchmark(Serializable):
         """
         return Distribution(data=[result.output_token_count for result in self.results])
 
+    @computed_field
+    @property
+    def output_token_percentiles(self) -> List[float]:
+        """
+        Get standard percentiles for number of output tokens.
+
+        :return: List of percentiles of number of output tokens.
+        :rtype: List[float]
+        """
+        return self.output_token_distribution.percentiles([1, 5, 50, 95, 99])
+
+    @computed_field
     @property
     def overloaded(self) -> bool:
         if (

--- a/src/guidellm/core/result.py
+++ b/src/guidellm/core/result.py
@@ -386,9 +386,11 @@ class TextGenerationBenchmark(Serializable):
     @property
     def time_to_first_token_percentiles(self) -> List[float]:
         """
-        Get standard percentiles for time taken to decode the first token in milliseconds.
+        Get standard percentiles for time taken to decode the first token
+        in milliseconds.
 
-        :return: List of percentile time taken to decode the first token in milliseconds.
+        :return: List of percentile time taken to decode the first token
+        in milliseconds.
         :rtype: List[float]
         """
         return self.ttft_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])

--- a/src/guidellm/core/result.py
+++ b/src/guidellm/core/result.py
@@ -381,7 +381,7 @@ class TextGenerationBenchmark(Serializable):
                 if result.first_token_time is not None
             ]
         )
-    
+
     @computed_field
     @property
     def time_to_first_token_percentiles(self) -> List[float]:
@@ -390,7 +390,7 @@ class TextGenerationBenchmark(Serializable):
 
         :return: List of percentile time taken to decode the first token in milliseconds.
         :rtype: List[float]
-        """        
+        """
         return self.ttft_distribution.percentiles([1, 5, 10, 50, 90, 95, 99])
 
     @computed_field
@@ -420,7 +420,7 @@ class TextGenerationBenchmark(Serializable):
                 decode for result in self.results for decode in result.decode_times.data
             ]
         )
-    
+
     @computed_field
     @property
     def inter_token_latency_percentiles(self) -> List[float]:


### PR DESCRIPTION
At the end of the run GuideLLM will print summary metrics that are computed from the raw results, but these are not currently saved anywhere.

This PR adds these metrics as serializable properties of the `TextGenerationBenchmark` class. Most of the metrics are already declared as properties, but are not serializable. Adding the `@computed_field` decorator is enough in these cases. Other properties were added to complete the list.