### PR TITLE
Multimodal

### DIFF
--- a/src/guidellm/config.py
+++ b/src/guidellm/config.py
@@ -90,6 +90,7 @@ class EmulatedDataSettings(BaseModel):
             "force_new_line_punctuation": True,
         }
     )
+    image_source: List[str] = "https://www.gutenberg.org/cache/epub/1342/pg1342-images.html"
 
 
 class OpenAISettings(BaseModel):

--- a/src/guidellm/core/request.py
+++ b/src/guidellm/core/request.py
@@ -1,9 +1,10 @@
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from pydantic import Field
 
 from guidellm.core.serializable import Serializable
+from guidellm.utils import ImageDescriptor
 
 
 class TextGenerationRequest(Serializable):
@@ -16,6 +17,10 @@ class TextGenerationRequest(Serializable):
         description="The unique identifier for the request.",
     )
     prompt: str = Field(description="The input prompt for the text generation.")
+    images: Optional[List[ImageDescriptor]] = Field(
+        default=None,
+        description="Input images.",
+    )
     prompt_token_count: Optional[int] = Field(
         default=None,
         description="The number of tokens in the input prompt.",
@@ -29,6 +34,13 @@ class TextGenerationRequest(Serializable):
         description="The parameters for the text generation request.",
     )
 
+    @property
+    def number_images(self) -> int:
+        if self.images is None:
+            return 0
+        else:
+            return len(self.images)
+
     def __str__(self) -> str:
         prompt_short = (
             self.prompt[:32] + "..."
@@ -41,4 +53,5 @@ class TextGenerationRequest(Serializable):
             f"prompt={prompt_short}, prompt_token_count={self.prompt_token_count}, "
             f"output_token_count={self.output_token_count}, "
             f"params={self.params})"
+            f"images={self.number_images}"
         )

--- a/src/guidellm/request/emulated.py
+++ b/src/guidellm/request/emulated.py
@@ -11,7 +11,7 @@ from transformers import PreTrainedTokenizer  # type: ignore  # noqa: PGH003
 from guidellm.config import settings
 from guidellm.core.request import TextGenerationRequest
 from guidellm.request.base import GenerationMode, RequestGenerator
-from guidellm.utils import clean_text, filter_text, load_text, split_text
+from guidellm.utils import clean_text, filter_text, load_text, split_text, load_images
 
 __all__ = ["EmulatedConfig", "EmulatedRequestGenerator", "EndlessTokens"]
 
@@ -30,6 +30,7 @@ class EmulatedConfig:
         generated_tokens_variance (Optional[int]): Variance for generated tokens.
         generated_tokens_min (Optional[int]): Minimum number of generated tokens.
         generated_tokens_max (Optional[int]): Maximum number of generated tokens.
+        images (Optional[int]): Number of input images.
     """
 
     @staticmethod
@@ -47,7 +48,7 @@ class EmulatedConfig:
         """
         if not config:
             logger.debug("Creating default configuration")
-            return EmulatedConfig(prompt_tokens=1024, generated_tokens=256)
+            return EmulatedConfig(prompt_tokens=1024, generated_tokens=256, images=0)
 
         if isinstance(config, dict):
             logger.debug("Loading configuration from dict: {}", config)
@@ -104,6 +105,8 @@ class EmulatedConfig:
     generated_tokens_variance: Optional[int] = None
     generated_tokens_min: Optional[int] = None
     generated_tokens_max: Optional[int] = None
+
+    images: int = 0
 
     @property
     def prompt_tokens_range(self) -> Tuple[int, int]:
@@ -327,6 +330,8 @@ class EmulatedRequestGenerator(RequestGenerator):
             settings.emulated_data.filter_start,
             settings.emulated_data.filter_end,
         )
+        if self._config.images > 0:
+            self._images = load_images(settings.emulated_data.image_source)
         self._rng = np.random.default_rng(random_seed)
 
         # NOTE: Must be after all the parameters since the queue population
@@ -355,6 +360,7 @@ class EmulatedRequestGenerator(RequestGenerator):
         logger.debug("Creating new text generation request")
         target_prompt_token_count = self._config.sample_prompt_tokens(self._rng)
         prompt = self.sample_prompt(target_prompt_token_count)
+        images = self.sample_images()
         prompt_token_count = len(self.tokenizer.tokenize(prompt))
         output_token_count = self._config.sample_output_tokens(self._rng)
         logger.debug("Generated prompt: {}", prompt)
@@ -363,6 +369,7 @@ class EmulatedRequestGenerator(RequestGenerator):
             prompt=prompt,
             prompt_token_count=prompt_token_count,
             output_token_count=output_token_count,
+            images=images,
         )
 
     def sample_prompt(self, tokens: int) -> str:
@@ -395,3 +402,9 @@ class EmulatedRequestGenerator(RequestGenerator):
                 right = mid
 
         return self._tokens.create_text(start_line_index, left)
+    
+    
+    def sample_images(self):
+        image_indices = self._rng.choice(len(self._images), size=self._config.images, replace=False)
+
+        return [self._images[i] for i in image_indices]

--- a/src/guidellm/utils/__init__.py
+++ b/src/guidellm/utils/__init__.py
@@ -12,6 +12,7 @@ from .text import (
     split_lines_by_punctuation,
     split_text,
 )
+from .images import load_images, ImageDescriptor
 from .transformers import (
     load_transformers_dataset,
     resolve_transformers_dataset,

--- a/src/guidellm/utils/images.py
+++ b/src/guidellm/utils/images.py
@@ -1,0 +1,69 @@
+from PIL import Image
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse
+from pydantic import Field, ConfigDict
+from typing import List, Optional
+from io import BytesIO
+
+from loguru import logger
+
+import requests
+
+from guidellm.config import settings
+from guidellm.core.serializable import Serializable
+
+__all__ = ["load_images", "ImageDescriptor"]
+
+class ImageDescriptor(Serializable):
+    """
+    A class to represent image data in serializable format.
+    """
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    
+    url: Optional[str] = Field(description="url address for image.")
+    image: Image.Image = Field(description="PIL image", exclude=True)
+    filename: Optional[int] = Field(
+        default=None,
+        description="Image filename.",
+    )
+    
+
+def load_images(data: str) -> List[ImageDescriptor]:
+    """
+    Load an HTML file from a path or URL
+
+    :param data: the path or URL to load the HTML file from
+    :type data: Union[str, Path]
+    :return: Descriptor containing image url and the data in PIL.Image.Image format
+    :rtype: ImageDescriptor
+    """
+
+    images = []
+    if not data:
+        return None
+    if isinstance(data, str) and data.startswith("http"):
+        response = requests.get(data, timeout=settings.request_timeout)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, 'html.parser')
+        for img_tag in soup.find_all("img"):
+            img_url = img_tag.get("src")
+
+            if img_url:
+                # Handle relative URLs
+                img_url = urljoin(data, img_url)
+                
+                # Download the image
+                logger.debug("Loading image: {}", img_url)
+                img_response = requests.get(img_url)
+                img_response.raise_for_status()
+                
+                # Load image into Pillow
+                images.append(
+                    ImageDescriptor(
+                        url=img_url, 
+                        image=Image.open(BytesIO(img_response.content)),
+                    )
+                )
+
+        return images


### PR DESCRIPTION
This PR adds support for benchmarking multimodal models.

It mostly extends existing infrastructure to add support to requests containing images. For emulated requests it downloads images from an illustrated version from Pride and Prejudice and randomly selects from them.

The load_images logic is currently limited to download from url. It should be extended to HF datasets or local files in the future.