### PR TITLE
Concurrent load generation option is implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ GuideLLM provides various CLI and environment options to customize evaluations, 
 
 Some typical configurations for the CLI include:
 
-- `--rate-type`: The rate to use for benchmarking. Options include `sweep`, `synchronous`, `throughput`, `constant`, and `poisson`.
+- `--rate-type`: The rate to use for benchmarking. Options include `sweep`, `synchronous`, `concurrent`, `throughput`, `constant`, and `poisson`.
   - `--rate-type sweep`: (default) Sweep runs through the full range of the server's performance, starting with a `synchronous` rate, then `throughput`, and finally, 10 `constant` rates between the min and max request rate found.
   - `--rate-type synchronous`: Synchronous runs requests synchronously, one after the other.
+  - `--rate-type concurrent`: Concurrent runs requests concurrently in multiple threads. One request per thread. Number of threads is specified with `--rate` argument.
   - `--rate-type throughput`: Throughput runs requests in a throughput manner, sending requests as fast as possible.
   - `--rate-type constant`: Constant runs requests at a constant rate. Specify the request rate per second with the `--rate` argument. For example, `--rate 10` or multiple rates with `--rate 10 --rate 20 --rate 30`.
   - `--rate-type poisson`: Poisson draws from a Poisson distribution with the mean at the specified rate, adding some real-world variance to the runs. Specify the request rate per second with the `--rate` argument. For example, `--rate 10` or multiple rates with `--rate 10 --rate 20 --rate 30`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ ignore = [
     "TCH002",
     "PLW1514", # allow Path.open without encoding
     "RET505", # allow `else` blocks
-    "RET506" # allow `else` blocks
+    "RET506", # allow `else` blocks
+    "C901"  # allow small if/else complexity
 
 ]
 select = [

--- a/src/guidellm/executor/profile_generator.py
+++ b/src/guidellm/executor/profile_generator.py
@@ -162,13 +162,6 @@ class ProfileGenerator:
         if self._mode in ["constant", "poisson"]:
             return [self._mode] * len(self._rates)
 
-        # WIP
-        # if self._mode in ["concurrent"]:
-        #     if self._rates is None:
-        #         raise ValueError("rate ")
-
-        #     return [self._mode] * int(self._rates[0])
-
         raise ValueError(f"Invalid mode: {self._mode}")
 
     def next(self, current_report: TextGenerationBenchmarkReport) -> Optional[Profile]:

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -264,7 +264,7 @@ def generate_benchmark_report(
         backend=backend_inst,
         request_generator=request_generator,
         mode=rate_type,
-        rate=rate if rate_type in ("constant", "poisson") else None,
+        rate=rate if rate_type in ("constant", "poisson", "concurrent") else None,
         max_number=(
             len(request_generator) if max_requests == "dataset" else max_requests
         ),

--- a/src/guidellm/scheduler/base.py
+++ b/src/guidellm/scheduler/base.py
@@ -316,7 +316,8 @@ class Scheduler:
         if self.mode == "consistent":
             if self.rate is None:
                 raise ValueError(
-                    "The rate must be specified in order to provide concurrent execution"
+                    "The `rate` must be specified in order to provide "
+                    "the concurrent execution"
                 )
             for index, request in enumerate(self.generator):
                 while (index + 1 - completed) >= settings.max_concurrency:

--- a/src/guidellm/scheduler/load_generator.py
+++ b/src/guidellm/scheduler/load_generator.py
@@ -6,7 +6,9 @@ from loguru import logger
 
 __all__ = ["LoadGenerationMode", "LoadGenerator"]
 
-LoadGenerationMode = Literal["synchronous", "constant", "poisson", "throughput"]
+LoadGenerationMode = Literal[
+    "synchronous", "constant", "poisson", "throughput", "consistent"
+]
 
 
 class LoadGenerator:
@@ -18,7 +20,7 @@ class LoadGenerator:
     timestamps based on the rate provided during initialization.
 
     :param mode: The mode of load generation. Valid options are "constant",
-        "poisson", "throughput", and "synchronous".
+        "poisson", "throughput", and "synchronous", "consistent"
     :type mode: LoadGenerationMode
     :param rate: The rate at which to generate timestamps. This value is
         interpreted differently depending on the mode.
@@ -52,8 +54,8 @@ class LoadGenerator:
             logger.error(error)
             raise error
 
-        self._mode = mode
-        self._rate = rate
+        self._mode: LoadGenerationMode = mode
+        self._rate: Optional[float] = rate
         logger.debug(
             "Initialized LoadGenerator with mode: {mode}, rate: {rate}",
             mode=mode,

--- a/tests/unit/scheduler/test_load_generator.py
+++ b/tests/unit/scheduler/test_load_generator.py
@@ -14,6 +14,7 @@ def test_load_generator_mode():
         "constant",
         "poisson",
         "throughput",
+        "consistent",
     }
 
 
@@ -21,10 +22,11 @@ def test_load_generator_mode():
 @pytest.mark.parametrize(
     ("mode", "rate"),
     [
+        ("synchronous", None),
         ("constant", 10),
         ("poisson", 5),
         ("throughput", None),
-        ("synchronous", None),
+        ("consistent", 2),
     ],
 )
 def test_load_generator_instantiation(mode, rate):


### PR DESCRIPTION
### Summary

- `--rate-type concurrent` is implemented as an additional Profile Generation mode.
    - if `--rate-type` is concurrent you must set the `--rate` which belongs to the number of concurrent workers that will be started to simulate multiple users working with the system.


### Detailed

- You can find the `consistent` type of Load Generation, which differs from the rest of the generation modes since the `consistent` does not use times to simulate delays. All the requests go one by one within a single asynchronous task.


### Example of usage

```sh
$ guidellm --target http://localhost:8080/v1 --model Phi-3-mini-4k-instruct-q4.gguf --data 'prompt_tokens=128,generated_tokens=128' --data-type emulated --tokenizer "hf-internal-testing/llama-tokenizer" --max-requests 2 --rate-type concurrent --rate 2

╭─ Benchmarks ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [10:43:43]   100% consistent   (0.13 req/sec avg)                                                                                                                                                             │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
  Generating report... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1/1) [ 0:00:29 < 0:00:00 ]
╭─ GuideLLM Benchmarks Report (stdout) ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─ Benchmark Report 1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ Backend(type=openai_server, target=http://localhost:8080/v1, model=Phi-3-mini-4k-instruct-q4.gguf)                                                                                                        │ │
│ │ Data(type=emulated, source=prompt_tokens=128,generated_tokens=128, tokenizer=hf-internal-testing/llama-tokenizer)                                                                                         │ │
│ │ Rate(type=concurrent, rate=(2.0,))                                                                                                                                                                        │ │
│ │ Limits(max_number=2 requests, max_duration=120 sec)                                                                                                                                                       │ │
│ │                                                                                                                                                                                                           │ │
│ │                                                                                                                                                                                                           │ │
│ │ Requests Data by Benchmark                                                                                                                                                                                │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓                                                                                                   │ │
│ │ ┃ Benchmark                 ┃ Requests Completed ┃ Request Failed ┃ Duration  ┃ Start Time ┃ End Time ┃                                                                                                   │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩                                                                                                   │ │
│ │ │ asynchronous@2.00 req/sec │ 4/4                │ 0/4            │ 29.74 sec │ 10:43:43   │ 10:44:12 │                                                                                                   │ │
│ │ └───────────────────────────┴────────────────────┴────────────────┴───────────┴────────────┴──────────┘                                                                                                   │ │
│ │                                                                                                                                                                                                           │ │
│ │ Tokens Data by Benchmark                                                                                                                                                                                  │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                                                   │ │
│ │ ┃ Benchmark                 ┃ Prompt ┃ Prompt (1%, 5%, 50%, 95%, 99%)    ┃ Output ┃ Output (1%, 5%, 50%, 95%, 99%)    ┃                                                                                   │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                                                   │ │
│ │ │ asynchronous@2.00 req/sec │ 128.00 │ 128.0, 128.0, 128.0, 128.0, 128.0 │ 128.00 │ 128.0, 128.0, 128.0, 128.0, 128.0 │                                                                                   │ │
│ │ └───────────────────────────┴────────┴───────────────────────────────────┴────────┴───────────────────────────────────┘                                                                                   │ │
│ │                                                                                                                                                                                                           │ │
│ │ Performance Stats by Benchmark                                                                                                                                                                            │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │ │
│ │ ┃                           ┃ Request Latency [1%, 5%, 10%, 50%, 90%, 95%, 99%]      ┃ Time to First Token [1%, 5%, 10%, 50%, 90%, 95%, 99%]   ┃ Inter Token Latency [1%, 5%, 10%, 50%, 90% 95%, 99%]   ┃ │ │
│ │ ┃ Benchmark                 ┃ (sec)                                                  ┃ (ms)                                                    ┃ (ms)                                                   ┃ │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │ │
│ │ │ asynchronous@2.00 req/sec │ 7.91, 8.79, 9.89, 18.70, 27.52, 28.62, 29.51           │ 1146.2, 2053.7, 3188.0, 12159.8, 20962.7, 22060.9,      │ 48.2, 49.1, 49.7, 51.3, 54.8, 57.3, 66.9               │ │ │
│ │ │                           │                                                        │ 22939.4                                                 │                                                        │ │ │
│ │ └───────────────────────────┴────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────┘ │ │
│ │                                                                                                                                                                                                           │ │
│ │ Performance Summary by Benchmark                                                                                                                                                                          │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                               │ │
│ │ ┃ Benchmark                 ┃ Requests per Second ┃ Request Latency ┃ Time to First Token ┃ Inter Token Latency ┃ Output Token Throughput ┃                                                               │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                               │ │
│ │ │ asynchronous@2.00 req/sec │ 0.13 req/sec        │ 18.71 sec       │ 12099.47 ms         │ 52.00 ms            │ 17.22 tokens/sec        │                                                               │ │
│ │ └───────────────────────────┴─────────────────────┴─────────────────┴─────────────────────┴─────────────────────┴─────────────────────────┘                                                               │ │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```

