### PR TITLE
`--batch-size` CLI parameter is added

### DIFF
--- a/src/guidellm/executor/base.py
+++ b/src/guidellm/executor/base.py
@@ -63,6 +63,7 @@ class Executor:
     :param max_duration: Maximum duration for generating requests for the scheduler,
         (a single report run), or None.
     :type max_duration: Optional[float]
+    :type batch_size: Optional[int]
     """
 
     def __init__(
@@ -73,12 +74,14 @@ class Executor:
         rate: Optional[Union[float, Sequence[float]]] = None,
         max_number: Optional[int] = None,
         max_duration: Optional[float] = None,
+        batch_size: Optional[int] = None,
     ):
         self._backend = backend
         self._generator = request_generator
         self._max_number = max_number
         self._max_duration = max_duration
         self._profile_generator = ProfileGenerator(mode=mode, rate=rate)
+        self._batch_size = batch_size
         logger.info("Executor initialized with mode: {}, rate: {}", mode, rate)
 
     @property
@@ -131,6 +134,16 @@ class Executor:
         """
         return self._max_duration
 
+    @property
+    def batch_size(self) -> Optional[int]:
+        """
+        Returns the number batch size.
+
+        :return: Number batch size.
+        :rtype: Optional[int]
+        """
+        return self._batch_size
+
     async def run(self) -> AsyncGenerator[ExecutorResult, None]:
         """
         Runs the Executor, generating and scheduling tasks based on the profile
@@ -154,6 +167,7 @@ class Executor:
             # limits args
             "max_number": self.max_number,
             "max_duration": self.max_duration,
+            "batch_size": self.batch_size,
         }
         profile_index = -1
         logger.info("Starting Executor run")
@@ -175,6 +189,7 @@ class Executor:
                 rate=profile.load_gen_rate,
                 max_number=self.max_number or profile.args.get("max_number", None),
                 max_duration=self.max_duration,
+                batch_size=self.batch_size,
             )
             profile_index += 1
 

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -132,6 +132,12 @@ __all__ = ["generate_benchmark_report"]
     ),
 )
 @click.option(
+    "--batch-size",
+    type=int,
+    default=None,
+    help="The batch size of inference requests.",
+)
+@click.option(
     "--output-path",
     type=str,
     default=None,
@@ -162,6 +168,7 @@ def generate_benchmark_report_cli(
     rate: Optional[float],
     max_seconds: Optional[int],
     max_requests: Union[Literal["dataset"], int, None],
+    batch_size: Optional[int],
     output_path: str,
     enable_continuous_refresh: bool,
 ):
@@ -179,6 +186,7 @@ def generate_benchmark_report_cli(
         rate=rate,
         max_seconds=max_seconds,
         max_requests=max_requests,
+        batch_size=batch_size,
         output_path=output_path,
         cont_refresh_table=enable_continuous_refresh,
     )
@@ -195,6 +203,7 @@ def generate_benchmark_report(
     rate: Optional[float],
     max_seconds: Optional[int],
     max_requests: Union[Literal["dataset"], int, None],
+    batch_size: Optional[int],
     output_path: str,
     cont_refresh_table: bool,
 ) -> GuidanceReport:
@@ -269,6 +278,7 @@ def generate_benchmark_report(
             len(request_generator) if max_requests == "dataset" else max_requests
         ),
         max_duration=max_seconds,
+        batch_size=batch_size,
     )
 
     # Run executor
@@ -281,6 +291,7 @@ def generate_benchmark_report(
             "rate": rate,
             "max_number": max_requests,
             "max_duration": max_seconds,
+            "batch_size": batch_size,
         },
     )
     report = asyncio.run(_run_executor_for_result(executor))

--- a/src/guidellm/scheduler/base.py
+++ b/src/guidellm/scheduler/base.py
@@ -36,7 +36,9 @@ class SchedulerResult:
     :param current_result: The result of the current request, if any.
     :type current_result: Optional[Union[TextGenerationResult, Exception]]
     :param batch_results: The result of the current batch of requests, if any
-    :type batch_results: Optional[List[Union[TextGenerationResult, TextGenerationError]]]
+    :type batch_results: Optional[List[
+                            Union[TextGenerationResult, TextGenerationError]]
+                         ]
     """
 
     completed: bool

--- a/src/guidellm/scheduler/base.py
+++ b/src/guidellm/scheduler/base.py
@@ -235,9 +235,6 @@ class Scheduler:
 
         return self._batch_size
 
-    async def _run_batch(self):
-        pass
-
     async def run(self) -> AsyncGenerator[SchedulerResult, None]:
         """
         Run the scheduler to process requests based on the configured mode, rate,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -252,6 +252,7 @@ def test_generate_benchmark_report_invoke_smoke(
         max_requests=10,
         output_path="benchmark_report.json",
         cont_refresh_table=False,
+        batch_size=None,
     )
     assert report is not None
 
@@ -308,6 +309,7 @@ def test_generate_benchmark_report_emulated_with_dataset_requests(
             rate=None,
             max_seconds=10,
             max_requests="dataset",
+            batch_size=None,
             output_path="benchmark_report.json",
             cont_refresh_table=False,
         )
@@ -397,6 +399,7 @@ def test_generate_benchmark_report_openai_limited_by_file_dataset(
             rate=rate,
             max_seconds=None,
             max_requests="dataset",
+            batch_size=None,
             output_path="benchmark_report.json",
             cont_refresh_table=False,
         )


### PR DESCRIPTION
### Setup the environment
1. Run the model via vllm or llama.cpp
2. Execute the `guidellm` command


### Command
```shell
guidellm --target "http://localhost:8080/v1" --model "neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16" --tokenizer "hf-internal-testing/llama-tokenizer" --data-type emulated --data "prompt_tokens=512,generated_tokens=128" --rate-type constant --rate 2 --max-seconds 100 --batch-size 2
```

### Output
```shell
  Generating report... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1/1) [ 0:01:40 < 0:00:00 ]
╭─ GuideLLM Benchmarks Report (stdout) ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─ Benchmark Report 1 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ Backend(type=openai_server, target=http://localhost:8080/v1, model=Phi-3-mini-4k-instruct-q4.gguf)                                                                                     │ │
│ │ Data(type=emulated, source=prompt_tokens=128,generated_tokens=128, tokenizer=hf-internal-testing/llama-tokenizer)                                                                      │ │
│ │ Rate(type=constant, rate=(8.0,))                                                                                                                                                       │ │
│ │ Limits(max_number=None requests, max_duration=100 sec)                                                                                                                                 │ │
│ │                                                                                                                                                                                        │ │
│ │                                                                                                                                                                                        │ │
│ │ Requests Data by Benchmark                                                                                                                                                             │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓                                                                                │ │
│ │ ┃ Benchmark                 ┃ Requests Completed ┃ Request Failed ┃ Duration  ┃ Start Time ┃ End Time ┃                                                                                │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩                                                                                │ │
│ │ │ asynchronous@8.00 req/sec │ 12/12              │ 0/12           │ 90.03 sec │ 21:46:41   │ 21:48:11 │                                                                                │ │
│ │ └───────────────────────────┴────────────────────┴────────────────┴───────────┴────────────┴──────────┘                                                                                │ │
│ │                                                                                                                                                                                        │ │
│ │ Tokens Data by Benchmark                                                                                                                                                               │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                                  │ │
│ │ ┃ Benchmark                 ┃ Prompt ┃ Prompt (1%, 5%, 50%, 95%, 99%)    ┃ Output ┃ Output (1%, 5%, 50%, 95%, 99%)  ┃                                                                  │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                                  │ │
│ │ │ asynchronous@8.00 req/sec │ 128.25 │ 128.0, 128.0, 128.0, 129.0, 129.0 │ 117.42 │ 56.3, 65.5, 128.0, 128.0, 128.0 │                                                                  │ │
│ │ └───────────────────────────┴────────┴───────────────────────────────────┴────────┴─────────────────────────────────┘                                                                  │ │
│ │                                                                                                                                                                                        │ │
│ │ Performance Stats by Benchmark                                                                                                                                                         │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │ │
│ │ ┃                           ┃ Request Latency [1%, 5%, 10%, 50%, 90%, 95%,     ┃ Time to First Token [1%, 5%, 10%, 50%, 90%, 95%, ┃ Inter Token Latency [1%, 5%, 10%, 50%, 90% 95%,  ┃ │ │
│ │ ┃ Benchmark                 ┃ 99%] (sec)                                       ┃ 99%] (ms)                                        ┃ 99%] (ms)                                        ┃ │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │ │
│ │ │ asynchronous@8.00 req/sec │ 7.76, 7.83, 7.91, 10.56, 16.01, 16.60, 17.16     │ 828.5, 830.6, 833.0, 4789.5, 9004.5, 9510.3,     │ 49.7, 51.1, 51.8, 55.0, 66.4, 70.4, 75.6         │ │ │
│ │ │                           │                                                  │ 9994.8                                           │                                                  │ │ │
│ │ └───────────────────────────┴──────────────────────────────────────────────────┴──────────────────────────────────────────────────┴──────────────────────────────────────────────────┘ │ │
│ │                                                                                                                                                                                        │ │
│ │ Performance Summary by Benchmark                                                                                                                                                       │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓                                            │ │
│ │ ┃ Benchmark                 ┃ Requests per Second ┃ Request Latency ┃ Time to First Token ┃ Inter Token Latency ┃ Output Token Throughput ┃                                            │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩                                            │ │
│ │ │ asynchronous@8.00 req/sec │ 0.13 req/sec        │ 11.60 sec       │ 4941.58 ms          │ 57.20 ms            │ 15.65 tokens/sec        │                                            │ │
│ │ └───────────────────────────┴─────────────────────┴─────────────────┴─────────────────────┴─────────────────────┴─────────────────────────┘                                            │ │
│ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```