### PR TITLE
Add backend_kwargs to generate_benchmark_report

### DIFF
--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Literal, Optional, Union, get_args
+from typing import Any, Literal, Mapping, Optional, Union, get_args
 
 import click
 from loguru import logger
@@ -197,6 +197,7 @@ def generate_benchmark_report(
     max_requests: Union[Literal["dataset"], int, None],
     output_path: str,
     cont_refresh_table: bool,
+    backend_kwargs: Mapping[str, Any] = {},
 ) -> GuidanceReport:
     """
     Generate a benchmark report for a specified backend and dataset.
@@ -218,6 +219,7 @@ def generate_benchmark_report(
     :param output_path: Path to save the output report file.
     :param cont_refresh_table: Continually refresh the table in the CLI
         until the user exits.
+    :param backend_kwargs: Additional keyword arguments for the backend.
     """
     logger.info(
         "Generating benchmark report with target: {}, backend: {}", target, backend
@@ -228,6 +230,7 @@ def generate_benchmark_report(
         backend_type=backend,
         target=target,
         model=model,
+        **backend_kwargs,
     )
 
     request_generator: RequestGenerator

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -197,7 +197,7 @@ def generate_benchmark_report(
     max_requests: Union[Literal["dataset"], int, None],
     output_path: str,
     cont_refresh_table: bool,
-    backend_kwargs: Mapping[str, Any] = {},
+    backend_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> GuidanceReport:
     """
     Generate a benchmark report for a specified backend and dataset.
@@ -230,7 +230,7 @@ def generate_benchmark_report(
         backend_type=backend,
         target=target,
         model=model,
-        **backend_kwargs,
+        **(backend_kwargs or {}),
     )
 
     request_generator: RequestGenerator


### PR DESCRIPTION
This PR adds support for passing additional keyword arguments to the backend used in the `generate_benchmark_report` function. This allows us to use the already-implemented [`request_args` parameter](https://github.com/neuralmagic/guidellm/blob/ecf2984645202eea022cc7c9f245947e2dd5457d/src/guidellm/backend/openai.py#L37) on `OpenAIBackend`, which is needed in order to pass [custom headers/query params/etc](https://github.com/openai/openai-python/blob/3e69750d47df4f0759d4a28ddc68e4b38756d9ca/src/openai/resources/beta/chat/completions.py#L100) to OpenAI chat completion requests.