### PR TITLE
``--rate-type concurrent`` CLI parameter is implemented

### DIFF
--- a/src/guidellm/executor/base.py
+++ b/src/guidellm/executor/base.py
@@ -53,7 +53,7 @@ class Executor:
     :type backend: Backend
     :param request_generator: The generator that creates requests for execution.
     :type request_generator: RequestGenerator
-    :param mode: The mode for profile generation (e.g., sweep, synchronous).
+    :param mode: The mode for profile generation (e.g., sweep, synchronous, concurrent).
     :type mode: ProfileGenerationMode
     :param rate: The list of rates for load generation, or None.
     :type rate: Optional[List[float]]

--- a/src/guidellm/main.py
+++ b/src/guidellm/main.py
@@ -264,7 +264,7 @@ def generate_benchmark_report(
         backend=backend_inst,
         request_generator=request_generator,
         mode=rate_type,
-        rate=rate if rate_type in ("constant", "poisson") else None,
+        rate=rate if rate_type in ("constant", "poisson", "concurrent") else None,
         max_number=(
             len(request_generator) if max_requests == "dataset" else max_requests
         ),

--- a/src/guidellm/scheduler/load_generator.py
+++ b/src/guidellm/scheduler/load_generator.py
@@ -6,7 +6,9 @@ from loguru import logger
 
 __all__ = ["LoadGenerationMode", "LoadGenerator"]
 
-LoadGenerationMode = Literal["synchronous", "constant", "poisson", "throughput"]
+LoadGenerationMode = Literal[
+    "synchronous", "constant", "poisson", "throughput", "concurrent"
+]
 
 
 class LoadGenerator:
@@ -52,8 +54,9 @@ class LoadGenerator:
             logger.error(error)
             raise error
 
-        self._mode = mode
-        self._rate = rate
+        self._mode: LoadGenerationMode = mode
+        self._rate: Optional[float] = rate
+
         logger.debug(
             "Initialized LoadGenerator with mode: {mode}, rate: {rate}",
             mode=mode,
@@ -100,6 +103,8 @@ class LoadGenerator:
             yield from self.poisson_times()
         elif self._mode == "synchronous":
             yield from self.synchronous_times()
+        elif self._mode == "concurrent":
+            yield from self.throughput_times()
         else:
             logger.error(f"Invalid mode encountered: {self._mode}")
             raise ValueError(f"Invalid mode: {self._mode}")

--- a/tests/unit/executor/test_profile_generator.py
+++ b/tests/unit/executor/test_profile_generator.py
@@ -19,6 +19,7 @@ def test_profile_generator_mode():
         "throughput",
         "constant",
         "poisson",
+        "concurrent",
     }
 
 
@@ -41,6 +42,7 @@ def test_profile_instantiation():
         ("constant", [10, 20, 30]),
         ("poisson", 10),
         ("poisson", [10, 20, 30]),
+        ("concurrent", 2),
     ],
 )
 def test_profile_generator_instantiation(mode, rate):
@@ -93,6 +95,8 @@ def test_profile_generator_instantiation(mode, rate):
         ("poisson", None),
         ("poisson", -1),
         ("poisson", 0),
+        ("concurrent", 0),
+        ("concurrent", -1),
     ],
 )
 def test_profile_generator_invalid_instantiation(mode, rate):
@@ -152,6 +156,20 @@ def test_profile_generator_next_throughput():
     profile: Profile = generator.next(current_report)  # type: ignore
     assert profile.load_gen_mode == "throughput"
     assert profile.load_gen_rate is None
+    assert generator.generated_count == 1
+
+    for _ in range(3):
+        assert generator.next(current_report) is None
+
+
+@pytest.mark.sanity()
+def test_profile_generator_next_concurrent():
+    generator = ProfileGenerator(mode="concurrent", rate=2.0)
+    current_report = TextGenerationBenchmarkReport()
+
+    profile: Profile = generator.next(current_report)  # type: ignore
+    assert profile.load_gen_mode == "concurrent"
+    assert profile.load_gen_rate == 2
     assert generator.generated_count == 1
 
     for _ in range(3):

--- a/tests/unit/scheduler/test_load_generator.py
+++ b/tests/unit/scheduler/test_load_generator.py
@@ -14,6 +14,7 @@ def test_load_generator_mode():
         "constant",
         "poisson",
         "throughput",
+        "concurrent",
     }
 
 
@@ -25,6 +26,7 @@ def test_load_generator_mode():
         ("poisson", 5),
         ("throughput", None),
         ("synchronous", None),
+        ("concurrent", 3),
     ],
 )
 def test_load_generator_instantiation(mode, rate):
@@ -40,6 +42,8 @@ def test_load_generator_instantiation(mode, rate):
         ("invalid_mode", None, ValueError),
         ("constant", 0, ValueError),
         ("poisson", -1, ValueError),
+        ("concurrent", -1, ValueError),
+        ("concurrent", 0, ValueError),
     ],
 )
 def test_load_generator_invalid_instantiation(mode, rate, expected_error):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ env_list = py38,py39,py310,py311,py312
 
 [testenv]
 description = Run all tests
+usedevelop = true
 deps =
     .[dev]
 commands =


### PR DESCRIPTION
### Execution example

```shell
(py38) ➜  guidellm git:(parfeniukink/concurrent-load-generation-v2) python src/guidellm/main.py --target http://localhost:8080/v1 --model Phi-3-mini-4k-instruct-q4.gguf --data 'prompt_tokens=128,generated_tokens=128' --data-type emulated --tokenizer "hf-internal-testing/llama-tokenizer" --max-requests 2 --rate-type concurrent --rate 2
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
╭─ Benchmarks ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [14:08:32]   100% concurrent   (0.12 req/sec avg)                                                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
  Generating report... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1/1) [ 0:00:16 < 0:00:00 ]
╭─ GuideLLM Benchmarks Report (stdout) ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─ Benchmark Report 1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮ │
│ │ Backend(type=openai_server, target=http://localhost:8080/v1, model=Phi-3-mini-4k-instruct-q4.gguf)                                                                                   │ │
│ │ Data(type=emulated, source=prompt_tokens=128,generated_tokens=128, tokenizer=hf-internal-testing/llama-tokenizer)                                                                    │ │
│ │ Rate(type=concurrent, rate=(2.0,))                                                                                                                                                   │ │
│ │ Limits(max_number=2 requests, max_duration=120 sec)                                                                                                                                  │ │
│ │                                                                                                                                                                                      │ │
│ │                                                                                                                                                                                      │ │
│ │ Requests Data by Benchmark                                                                                                                                                           │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┓                                                                              │ │
│ │ ┃ Benchmark                 ┃ Requests Completed ┃ Request Failed ┃ Duration  ┃ Start Time ┃ End Time ┃                                                                              │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━┩                                                                              │ │
│ │ │ asynchronous@2.00 req/sec │ 4/4                │ 0/4            │ 32.05 sec │ 14:08:32   │ 14:09:04 │                                                                              │ │
│ │ └───────────────────────────┴────────────────────┴────────────────┴───────────┴────────────┴──────────┘                                                                              │ │
│ │                                                                                                                                                                                      │ │
│ │ Tokens Data by Benchmark                                                                                                                                                             │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                              │ │
│ │ ┃ Benchmark                 ┃ Prompt ┃ Prompt (1%, 5%, 50%, 95%, 99%)    ┃ Output ┃ Output (1%, 5%, 50%, 95%, 99%)    ┃                                                              │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                              │ │
│ │ │ asynchronous@2.00 req/sec │ 129.00 │ 129.0, 129.0, 129.0, 129.0, 129.0 │ 128.00 │ 128.0, 128.0, 128.0, 128.0, 128.0 │                                                              │ │
│ │ └───────────────────────────┴────────┴───────────────────────────────────┴────────┴───────────────────────────────────┘                                                              │ │
│ │                                                                                                                                                                                      │ │
│ │ Performance Stats by Benchmark                                                                                                                                                       │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │ │
│ │ ┃                           ┃ Request Latency [1%, 5%, 10%, 50%, 90%, 95%,    ┃ Time to First Token [1%, 5%, 10%, 50%, 90%,     ┃ Inter Token Latency [1%, 5%, 10%, 50%, 90% 95%,  ┃ │ │
│ │ ┃ Benchmark                 ┃ 99%] (sec)                                      ┃ 95%, 99%] (ms)                                  ┃ 99%] (ms)                                        ┃ │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │ │
│ │ │ asynchronous@2.00 req/sec │ 8.50, 9.46, 10.65, 20.20, 29.68, 30.85, 31.80   │ 1365.0, 2316.8, 3506.6, 13039.3, 22588.4,       │ 50.8, 51.4, 51.7, 54.7, 62.3, 68.1, 73.6         │ │ │
│ │ │                           │                                                 │ 23781.6, 24736.2                                │                                                  │ │ │
│ │ └───────────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────┴──────────────────────────────────────────────────┘ │ │
│ │                                                                                                                                                                                      │ │
│ │ Performance Summary by Benchmark                                                                                                                                                     │ │
│ │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓                                          │ │
│ │ ┃ Benchmark                 ┃ Requests per Second ┃ Request Latency ┃ Time to First Token ┃ Inter Token Latency ┃ Output Token Throughput ┃                                          │ │
│ │ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩                                          │ │
│ │ │ asynchronous@2.00 req/sec │ 0.12 req/sec        │ 20.17 sec       │ 13045.15 ms         │ 56.12 ms            │ 15.98 tokens/sec        │                                          │ │
│ │ └───────────────────────────┴─────────────────────┴─────────────────┴─────────────────────┴─────────────────────┴─────────────────────────┘                                          │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### `tox` local report

> for some reason GitHub has some issues with quality checks. Here is report from local:

![Alacritty 2025-02-27](https://github.com/user-attachments/assets/d3fcc956-4372-4105-b584-7627675527e8)
