### PR TITLE
Fix argument error in nightly unit tests

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -113,8 +113,14 @@ jobs:
           if-no-files-found: error
           retention-days: 30
       - name: Comment Install instructions
-        uses: mshick/add-pr-comment@v2
+        uses: actions/github-script@v7
         with:
-          message: |
-            Build artifacts (.whl and .tar.gz) are available for download for up to 30 days.
-            They are located at ${{ steps.artifact-upload.outputs.artifact-url }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Build artifacts (.whl and .tar.gz) are available for download for up to 30 days.
+              They are located at ${{ steps.artifact-upload.outputs.artifact-url }}`
+            })

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: pip install tox
       - name: Run unit tests
-        run: tox -e test-unit -- -m --cov=guidellm --cov-report=term-missing --cov-fail-under=75
+        run: tox -e test-unit -- --cov=guidellm --cov-report=term-missing --cov-fail-under=75
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflow still fails since we don't meet the coverage target. Retry of #130 