### PR TITLE
Allow extra query params to be sent to the OpenAI server

### DIFF
--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -30,9 +30,10 @@ __all__ = [
 TEXT_COMPLETIONS_PATH = "/v1/completions"
 CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
 
-CHAT_COMPLETIONS = "chat_completions"
-MODELS = "models"
-TEXT_COMPLETIONS = "text_completions"
+EndpointType = Literal["chat_completions", "models", "text_completions"]
+CHAT_COMPLETIONS: EndpointType = "chat_completions"
+MODELS: EndpointType = "models"
+TEXT_COMPLETIONS: EndpointType = "text_completions"
 
 
 @Backend.register("openai_http")
@@ -82,7 +83,7 @@ class OpenAIHTTPBackend(Backend):
         http2: Optional[bool] = True,
         follow_redirects: Optional[bool] = None,
         max_output_tokens: Optional[int] = None,
-        extra_query: Optional[Union[dict[str, str], dict[str, dict[str, str]]]] = None,
+        extra_query: Optional[dict] = None,
     ):
         super().__init__(type_="openai_http")
         self._target = target or settings.openai.base_url
@@ -382,9 +383,7 @@ class OpenAIHTTPBackend(Backend):
 
         return headers
 
-    def _params(
-        self, endpoint_type: Literal["chat_completions", "models", "text_completions"]
-    ) -> dict[str, str]:
+    def _params(self, endpoint_type: EndpointType) -> dict[str, str]:
         if self.extra_query is None:
             return {}
 

--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -546,7 +546,8 @@ class OpenAIHTTPBackend(Backend):
                     response_output_count = usage["output"]
 
         logger.info(
-            "{} request: {} with headers: {} and params: {} and payload: {} completed with: {}",
+            "{} request: {} with headers: {} and params: {} and payload: {} completed"
+            "with: {}",
             self.__class__.__name__,
             request_id,
             headers,

--- a/src/guidellm/backend/response.py
+++ b/src/guidellm/backend/response.py
@@ -48,6 +48,7 @@ class RequestArgs(StandardBaseModel):
 
     :param target: The target URL or function for the request.
     :param headers: The headers, if any, included in the request such as authorization.
+    :param params: The query parameters, if any, included in the request.
     :param payload: The payload / arguments for the request including the prompt /
         content and other configurations.
     :param timeout: The timeout for the request in seconds, if any.
@@ -56,6 +57,7 @@ class RequestArgs(StandardBaseModel):
 
     target: str
     headers: dict[str, str]
+    params: dict[str, str]
     payload: dict[str, Any]
     timeout: Optional[float] = None
     http2: Optional[bool] = None

--- a/src/guidellm/dataset/synthetic.py
+++ b/src/guidellm/dataset/synthetic.py
@@ -201,8 +201,8 @@ class SyntheticTextItemsGenerator(
 class SyntheticDatasetCreator(DatasetCreator):
     @classmethod
     def is_supported(
-        cls, data: Any, data_args: Optional[dict[str, Any]]
-    ) -> bool:  # noqa: ARG003
+        cls, data: Any, data_args: Optional[dict[str, Any]]  # noqa: ARG003
+    ) -> bool:
         if (
             isinstance(data, Path)
             and data.exists()

--- a/src/guidellm/dataset/synthetic.py
+++ b/src/guidellm/dataset/synthetic.py
@@ -200,7 +200,9 @@ class SyntheticTextItemsGenerator(
 
 class SyntheticDatasetCreator(DatasetCreator):
     @classmethod
-    def is_supported(cls, data: Any, data_args: Optional[dict[str, Any]]) -> bool:  # noqa: ARG003
+    def is_supported(
+        cls, data: Any, data_args: Optional[dict[str, Any]]
+    ) -> bool:  # noqa: ARG003
         if (
             isinstance(data, Path)
             and data.exists()

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -475,6 +475,7 @@ class GenerativeRequestsWorker(RequestsWorker[GenerationRequest, ResponseSummary
                 request_args=RequestArgs(
                     target=self.backend.target,
                     headers={},
+                    params={},
                     payload={},
                 ),
                 start_time=resolve_start_time,
@@ -490,6 +491,7 @@ class GenerativeRequestsWorker(RequestsWorker[GenerationRequest, ResponseSummary
                 request_args=RequestArgs(
                     target=self.backend.target,
                     headers={},
+                    params={},
                     payload={},
                 ),
                 start_time=response.start_time,

--- a/tests/unit/backend/test_openai_backend.py
+++ b/tests/unit/backend/test_openai_backend.py
@@ -17,6 +17,7 @@ def test_openai_http_backend_default_initialization():
     assert backend.timeout == settings.request_timeout
     assert backend.http2 is True
     assert backend.max_output_tokens == settings.openai.max_output_tokens
+    assert backend.extra_query is None
 
 
 @pytest.mark.smoke
@@ -30,6 +31,7 @@ def test_openai_http_backend_intialization():
         timeout=10,
         http2=False,
         max_output_tokens=100,
+        extra_query={"foo": "bar"},
     )
     assert backend.target == "http://test-target"
     assert backend.model == "test-model"
@@ -39,6 +41,7 @@ def test_openai_http_backend_intialization():
     assert backend.timeout == 10
     assert backend.http2 is False
     assert backend.max_output_tokens == 100
+    assert backend.extra_query["foo"] == "bar"
 
 
 @pytest.mark.smoke

--- a/tests/unit/backend/test_openai_backend.py
+++ b/tests/unit/backend/test_openai_backend.py
@@ -44,7 +44,7 @@ def test_openai_http_backend_intialization():
     assert backend.http2 is False
     assert backend.follow_redirects is False
     assert backend.max_output_tokens == 100
-    assert backend.extra_query["foo"] == "bar"
+    assert backend.extra_query == {"foo": "bar"}
 
 
 @pytest.mark.smoke

--- a/tests/unit/backend/test_response.py
+++ b/tests/unit/backend/test_response.py
@@ -76,6 +76,7 @@ def test_request_args_default_initialization():
     args = RequestArgs(
         target="http://example.com",
         headers={},
+        params={},
         payload={},
     )
     assert args.timeout is None
@@ -89,6 +90,7 @@ def test_request_args_initialization():
         headers={
             "Authorization": "Bearer token",
         },
+        params={},
         payload={
             "query": "Hello, world!",
         },
@@ -107,6 +109,7 @@ def test_response_args_marshalling():
     args = RequestArgs(
         target="http://example.com",
         headers={"Authorization": "Bearer token"},
+        params={},
         payload={"query": "Hello, world!"},
         timeout=10.0,
         http2=True,
@@ -125,6 +128,7 @@ def test_response_summary_default_initialization():
         request_args=RequestArgs(
             target="http://example.com",
             headers={},
+            params={},
             payload={},
         ),
         start_time=0.0,
@@ -155,6 +159,7 @@ def test_response_summary_initialization():
         request_args=RequestArgs(
             target="http://example.com",
             headers={},
+            params={},
             payload={},
         ),
         start_time=1.0,

--- a/tests/unit/mock_backend.py
+++ b/tests/unit/mock_backend.py
@@ -142,6 +142,7 @@ class MockBackend(Backend):
             request_args=RequestArgs(
                 target=self.target,
                 headers={},
+                params={},
                 payload={"prompt": prompt, "output_token_count": output_token_count},
             ),
             iterations=len(tokens),


### PR DESCRIPTION
Prior to the `openai_server` -> `openai_http` refactor (#91), we were using the `extra_query` parameter [in the OpenAI client](https://github.com/openai/openai-python/blob/fad098ffad7982a5150306a3d17f51ffef574f2e/src/openai/resources/models.py#L50) to send custom query parameters to the OpenAI server in requests made by guidellm. This PR adds that parameter to the new `OpenAIHTTPBackend`, making it possible to add custom query parameters that are included in every request sent to the server.