### PR TITLE
Add follow_redirects parameter to OpenAIHTTPBackend

### DIFF
--- a/src/guidellm/backend/openai.py
+++ b/src/guidellm/backend/openai.py
@@ -50,7 +50,7 @@ class OpenAIHTTPBackend(Backend):
     :param http2: If True, uses HTTP/2 for requests to the OpenAI server.
         Defaults to True.
     :param follow_redirects: If True, the HTTP client will follow redirect responses.
-        If not procided, the default value from settings is used.
+        If not provided, the default value from settings is used.
     :param max_output_tokens: The maximum number of tokens to request for completions.
         If not provided, the default maximum tokens provided from settings is used.
     """

--- a/src/guidellm/backend/response.py
+++ b/src/guidellm/backend/response.py
@@ -52,6 +52,7 @@ class RequestArgs(StandardBaseModel):
         content and other configurations.
     :param timeout: The timeout for the request in seconds, if any.
     :param http2: Whether HTTP/2 was used for the request, if applicable.
+    :param follow_redirects: Whether the request should follow redirect responses.
     """
 
     target: str
@@ -59,6 +60,7 @@ class RequestArgs(StandardBaseModel):
     payload: dict[str, Any]
     timeout: Optional[float] = None
     http2: Optional[bool] = None
+    follow_redirects: Optional[bool] = None
 
 
 class ResponseSummary(StandardBaseModel):

--- a/src/guidellm/config.py
+++ b/src/guidellm/config.py
@@ -115,6 +115,7 @@ class Settings(BaseSettings):
     default_sweep_number: int = 10
 
     # HTTP settings
+    request_follow_redirects: bool = True
     request_timeout: int = 60 * 5  # 5 minutes
     request_http2: bool = True
 

--- a/tests/unit/backend/test_openai_backend.py
+++ b/tests/unit/backend/test_openai_backend.py
@@ -16,6 +16,7 @@ def test_openai_http_backend_default_initialization():
     assert backend.project == settings.openai.project
     assert backend.timeout == settings.request_timeout
     assert backend.http2 is True
+    assert backend.follow_redirects is True
     assert backend.max_output_tokens == settings.openai.max_output_tokens
 
 
@@ -29,6 +30,7 @@ def test_openai_http_backend_intialization():
         project="test-proj",
         timeout=10,
         http2=False,
+        follow_redirects=False,
         max_output_tokens=100,
     )
     assert backend.target == "http://test-target"
@@ -38,6 +40,7 @@ def test_openai_http_backend_intialization():
     assert backend.project == "test-proj"
     assert backend.timeout == 10
     assert backend.http2 is False
+    assert backend.follow_redirects is False
     assert backend.max_output_tokens == 100
 
 

--- a/tests/unit/backend/test_response.py
+++ b/tests/unit/backend/test_response.py
@@ -80,6 +80,7 @@ def test_request_args_default_initialization():
     )
     assert args.timeout is None
     assert args.http2 is None
+    assert args.follow_redirects is None
 
 
 @pytest.mark.smoke
@@ -94,12 +95,14 @@ def test_request_args_initialization():
         },
         timeout=10.0,
         http2=True,
+        follow_redirects=True,
     )
     assert args.target == "http://example.com"
     assert args.headers == {"Authorization": "Bearer token"}
     assert args.payload == {"query": "Hello, world!"}
     assert args.timeout == 10.0
     assert args.http2 is True
+    assert args.follow_redirects is True
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
This PR adds the ability to set `follow_redirects` on the httpx client used to make requests to the OpenAI backend, allowing it to follow the redirect URL in 3xx responses. Following a discussion with @markurtz, this value defaults to true, but may be overwritten through environment variables or the `OpenAIHTTPBackend` initializer.