### PR TITLE
Fead/add preprocess dataset [Issue-106]

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -41,7 +41,6 @@ def parse_number_str(ctx, param, value):  # noqa: ARG001
 
 @click.group()
 def cli():
-    """GuideLLM CLI tools."""
     pass
 
 
@@ -58,8 +57,8 @@ def cli():
     "--backend-type",
     type=click.Choice(list(get_args(BackendType))),
     help=(
-            "The type of backend to use to run requests against. Defaults to 'openai_http'."
-            f" Supported types: {', '.join(get_args(BackendType))}"
+        "The type of backend to use to run requests against. Defaults to 'openai_http'."
+        f" Supported types: {', '.join(get_args(BackendType))}"
     ),
     default="openai_http",
 )
@@ -68,8 +67,8 @@ def cli():
     callback=parse_json,
     default=None,
     help=(
-            "A JSON string containing any arguments to pass to the backend as a "
-            "dict with **kwargs."
+        "A JSON string containing any arguments to pass to the backend as a "
+        "dict with **kwargs."
     ),
 )
 @click.option(
@@ -77,8 +76,8 @@ def cli():
     default=None,
     type=str,
     help=(
-            "The ID of the model to benchmark within the backend. "
-            "If None provided (default), then it will use the first model available."
+        "The ID of the model to benchmark within the backend. "
+        "If None provided (default), then it will use the first model available."
     ),
 )
 @click.option(
@@ -86,9 +85,9 @@ def cli():
     default=None,
     type=str,
     help=(
-            "The processor or tokenizer to use to calculate token counts for statistics "
-            "and synthetic data generation. If None provided (default), will load "
-            "using the model arg, if needed."
+        "The processor or tokenizer to use to calculate token counts for statistics "
+        "and synthetic data generation. If None provided (default), will load "
+        "using the model arg, if needed."
     ),
 )
 @click.option(
@@ -96,8 +95,8 @@ def cli():
     default=None,
     callback=parse_json,
     help=(
-            "A JSON string containing any arguments to pass to the processor constructor "
-            "as a dict with **kwargs."
+        "A JSON string containing any arguments to pass to the processor constructor "
+        "as a dict with **kwargs."
     ),
 )
 @click.option(
@@ -105,17 +104,17 @@ def cli():
     required=True,
     type=str,
     help=(
-            "The HuggingFace dataset ID, a path to a HuggingFace dataset, "
-            "a path to a data file csv, json, jsonl, or txt, "
-            "or a synthetic data config as a json or key=value string."
+        "The HuggingFace dataset ID, a path to a HuggingFace dataset, "
+        "a path to a data file csv, json, jsonl, or txt, "
+        "or a synthetic data config as a json or key=value string."
     ),
 )
 @click.option(
     "--data-args",
     callback=parse_json,
     help=(
-            "A JSON string containing any arguments to pass to the dataset creation "
-            "as a dict with **kwargs."
+        "A JSON string containing any arguments to pass to the dataset creation "
+        "as a dict with **kwargs."
     ),
 )
 @click.option(
@@ -123,8 +122,8 @@ def cli():
     default=None,
     type=click.Choice(["random"]),
     help=(
-            "The data sampler type to use. 'random' will add a random shuffle on the data. "
-            "Defaults to None"
+        "The data sampler type to use. 'random' will add a random shuffle on the data. "
+        "Defaults to None"
     ),
 )
 @click.option(
@@ -132,8 +131,8 @@ def cli():
     required=True,
     type=click.Choice(STRATEGY_PROFILE_CHOICES),
     help=(
-            "The type of benchmark to run. "
-            f"Supported types {', '.join(STRATEGY_PROFILE_CHOICES)}. "
+        "The type of benchmark to run. "
+        f"Supported types {', '.join(STRATEGY_PROFILE_CHOICES)}. "
     ),
 )
 @click.option(
@@ -141,28 +140,28 @@ def cli():
     default=None,
     callback=parse_number_str,
     help=(
-            "The rates to run the benchmark at. "
-            "Can be a single number or a comma-separated list of numbers. "
-            "For rate-type=sweep, this is the number of benchmarks it runs in the sweep. "
-            "For rate-type=concurrent, this is the number of concurrent requests. "
-            "For rate-type=async,constant,poisson, this is the rate requests per second. "
-            "For rate-type=synchronous,throughput, this must not be set."
+        "The rates to run the benchmark at. "
+        "Can be a single number or a comma-separated list of numbers. "
+        "For rate-type=sweep, this is the number of benchmarks it runs in the sweep. "
+        "For rate-type=concurrent, this is the number of concurrent requests. "
+        "For rate-type=async,constant,poisson, this is the rate requests per second. "
+        "For rate-type=synchronous,throughput, this must not be set."
     ),
 )
 @click.option(
     "--max-seconds",
     type=float,
     help=(
-            "The maximum number of seconds each benchmark can run for. "
-            "If None, will run until max_requests or the data is exhausted."
+        "The maximum number of seconds each benchmark can run for. "
+        "If None, will run until max_requests or the data is exhausted."
     ),
 )
 @click.option(
     "--max-requests",
     type=int,
     help=(
-            "The maximum number of requests each benchmark can run for. "
-            "If None, will run until max_seconds or the data is exhausted."
+        "The maximum number of requests each benchmark can run for. "
+        "If None, will run until max_seconds or the data is exhausted."
     ),
 )
 @click.option(
@@ -170,18 +169,18 @@ def cli():
     type=float,
     default=None,
     help=(
-            "The percent of the benchmark (based on max-seconds, max-requets, "
-            "or lenth of dataset) to run as a warmup and not include in the final results. "
-            "Defaults to None."
+        "The percent of the benchmark (based on max-seconds, max-requets, "
+        "or lenth of dataset) to run as a warmup and not include in the final results. "
+        "Defaults to None."
     ),
 )
 @click.option(
     "--cooldown-percent",
     type=float,
     help=(
-            "The percent of the benchmark (based on max-seconds, max-requets, or lenth "
-            "of dataset) to run as a cooldown and not include in the final results. "
-            "Defaults to None."
+        "The percent of the benchmark (based on max-seconds, max-requets, or lenth "
+        "of dataset) to run as a cooldown and not include in the final results. "
+        "Defaults to None."
     ),
 )
 @click.option(
@@ -204,10 +203,10 @@ def cli():
     type=click.Path(),
     default=Path.cwd() / "benchmarks.json",
     help=(
-            "The path to save the output to. If it is a directory, "
-            "it will save benchmarks.json under it. "
-            "Otherwise, json, yaml, or csv files are supported for output types "
-            "which will be read from the extension for the file path."
+        "The path to save the output to. If it is a directory, "
+        "it will save benchmarks.json under it. "
+        "Otherwise, json, yaml, or csv files are supported for output types "
+        "which will be read from the extension for the file path."
     ),
 )
 @click.option(
@@ -219,8 +218,8 @@ def cli():
     "--output-sampling",
     type=int,
     help=(
-            "The number of samples to save in the output file. "
-            "If None (default), will save all samples."
+        "The number of samples to save in the output file. "
+        "If None (default), will save all samples."
     ),
     default=None,
 )
@@ -231,28 +230,28 @@ def cli():
     help="The random seed to use for benchmarking to ensure reproducibility.",
 )
 def benchmark(
-        target,
-        backend_type,
-        backend_args,
-        model,
-        processor,
-        processor_args,
-        data,
-        data_args,
-        data_sampler,
-        rate_type,
-        rate,
-        max_seconds,
-        max_requests,
-        warmup_percent,
-        cooldown_percent,
-        disable_progress,
-        display_scheduler_stats,
-        disable_console_outputs,
-        output_path,
-        output_extras,
-        output_sampling,
-        random_seed,
+    target,
+    backend_type,
+    backend_args,
+    model,
+    processor,
+    processor_args,
+    data,
+    data_args,
+    data_sampler,
+    rate_type,
+    rate,
+    max_seconds,
+    max_requests,
+    warmup_percent,
+    cooldown_percent,
+    disable_progress,
+    display_scheduler_stats,
+    disable_console_outputs,
+    output_path,
+    output_extras,
+    output_sampling,
+    random_seed,
 ):
     asyncio.run(
         benchmark_generative_text(
@@ -284,8 +283,8 @@ def benchmark(
 
 @cli.command(
     help=(
-            "Print out the available configuration settings that can be set "
-            "through environment variables."
+        "Print out the available configuration settings that can be set "
+        "through environment variables."
     )
 )
 def config():

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -8,6 +8,7 @@ import click
 from guidellm.backend import BackendType
 from guidellm.benchmark import ProfileType, benchmark_generative_text
 from guidellm.config import print_config
+from guidellm.preprocess.dataset import process_dataset, ShortPromptStrategy
 from guidellm.scheduler import StrategyType
 
 STRATEGY_PROFILE_CHOICES = set(
@@ -40,6 +41,7 @@ def parse_number_str(ctx, param, value):  # noqa: ARG001
 
 @click.group()
 def cli():
+    """GuideLLM CLI tools."""
     pass
 
 
@@ -56,8 +58,8 @@ def cli():
     "--backend-type",
     type=click.Choice(list(get_args(BackendType))),
     help=(
-        "The type of backend to use to run requests against. Defaults to 'openai_http'."
-        f" Supported types: {', '.join(get_args(BackendType))}"
+            "The type of backend to use to run requests against. Defaults to 'openai_http'."
+            f" Supported types: {', '.join(get_args(BackendType))}"
     ),
     default="openai_http",
 )
@@ -66,8 +68,8 @@ def cli():
     callback=parse_json,
     default=None,
     help=(
-        "A JSON string containing any arguments to pass to the backend as a "
-        "dict with **kwargs."
+            "A JSON string containing any arguments to pass to the backend as a "
+            "dict with **kwargs."
     ),
 )
 @click.option(
@@ -75,8 +77,8 @@ def cli():
     default=None,
     type=str,
     help=(
-        "The ID of the model to benchmark within the backend. "
-        "If None provided (default), then it will use the first model available."
+            "The ID of the model to benchmark within the backend. "
+            "If None provided (default), then it will use the first model available."
     ),
 )
 @click.option(
@@ -84,9 +86,9 @@ def cli():
     default=None,
     type=str,
     help=(
-        "The processor or tokenizer to use to calculate token counts for statistics "
-        "and synthetic data generation. If None provided (default), will load "
-        "using the model arg, if needed."
+            "The processor or tokenizer to use to calculate token counts for statistics "
+            "and synthetic data generation. If None provided (default), will load "
+            "using the model arg, if needed."
     ),
 )
 @click.option(
@@ -94,8 +96,8 @@ def cli():
     default=None,
     callback=parse_json,
     help=(
-        "A JSON string containing any arguments to pass to the processor constructor "
-        "as a dict with **kwargs."
+            "A JSON string containing any arguments to pass to the processor constructor "
+            "as a dict with **kwargs."
     ),
 )
 @click.option(
@@ -103,17 +105,17 @@ def cli():
     required=True,
     type=str,
     help=(
-        "The HuggingFace dataset ID, a path to a HuggingFace dataset, "
-        "a path to a data file csv, json, jsonl, or txt, "
-        "or a synthetic data config as a json or key=value string."
+            "The HuggingFace dataset ID, a path to a HuggingFace dataset, "
+            "a path to a data file csv, json, jsonl, or txt, "
+            "or a synthetic data config as a json or key=value string."
     ),
 )
 @click.option(
     "--data-args",
     callback=parse_json,
     help=(
-        "A JSON string containing any arguments to pass to the dataset creation "
-        "as a dict with **kwargs."
+            "A JSON string containing any arguments to pass to the dataset creation "
+            "as a dict with **kwargs."
     ),
 )
 @click.option(
@@ -121,8 +123,8 @@ def cli():
     default=None,
     type=click.Choice(["random"]),
     help=(
-        "The data sampler type to use. 'random' will add a random shuffle on the data. "
-        "Defaults to None"
+            "The data sampler type to use. 'random' will add a random shuffle on the data. "
+            "Defaults to None"
     ),
 )
 @click.option(
@@ -130,8 +132,8 @@ def cli():
     required=True,
     type=click.Choice(STRATEGY_PROFILE_CHOICES),
     help=(
-        "The type of benchmark to run. "
-        f"Supported types {', '.join(STRATEGY_PROFILE_CHOICES)}. "
+            "The type of benchmark to run. "
+            f"Supported types {', '.join(STRATEGY_PROFILE_CHOICES)}. "
     ),
 )
 @click.option(
@@ -139,28 +141,28 @@ def cli():
     default=None,
     callback=parse_number_str,
     help=(
-        "The rates to run the benchmark at. "
-        "Can be a single number or a comma-separated list of numbers. "
-        "For rate-type=sweep, this is the number of benchmarks it runs in the sweep. "
-        "For rate-type=concurrent, this is the number of concurrent requests. "
-        "For rate-type=async,constant,poisson, this is the rate requests per second. "
-        "For rate-type=synchronous,throughput, this must not be set."
+            "The rates to run the benchmark at. "
+            "Can be a single number or a comma-separated list of numbers. "
+            "For rate-type=sweep, this is the number of benchmarks it runs in the sweep. "
+            "For rate-type=concurrent, this is the number of concurrent requests. "
+            "For rate-type=async,constant,poisson, this is the rate requests per second. "
+            "For rate-type=synchronous,throughput, this must not be set."
     ),
 )
 @click.option(
     "--max-seconds",
     type=float,
     help=(
-        "The maximum number of seconds each benchmark can run for. "
-        "If None, will run until max_requests or the data is exhausted."
+            "The maximum number of seconds each benchmark can run for. "
+            "If None, will run until max_requests or the data is exhausted."
     ),
 )
 @click.option(
     "--max-requests",
     type=int,
     help=(
-        "The maximum number of requests each benchmark can run for. "
-        "If None, will run until max_seconds or the data is exhausted."
+            "The maximum number of requests each benchmark can run for. "
+            "If None, will run until max_seconds or the data is exhausted."
     ),
 )
 @click.option(
@@ -168,18 +170,18 @@ def cli():
     type=float,
     default=None,
     help=(
-        "The percent of the benchmark (based on max-seconds, max-requets, "
-        "or lenth of dataset) to run as a warmup and not include in the final results. "
-        "Defaults to None."
+            "The percent of the benchmark (based on max-seconds, max-requets, "
+            "or lenth of dataset) to run as a warmup and not include in the final results. "
+            "Defaults to None."
     ),
 )
 @click.option(
     "--cooldown-percent",
     type=float,
     help=(
-        "The percent of the benchmark (based on max-seconds, max-requets, or lenth "
-        "of dataset) to run as a cooldown and not include in the final results. "
-        "Defaults to None."
+            "The percent of the benchmark (based on max-seconds, max-requets, or lenth "
+            "of dataset) to run as a cooldown and not include in the final results. "
+            "Defaults to None."
     ),
 )
 @click.option(
@@ -202,10 +204,10 @@ def cli():
     type=click.Path(),
     default=Path.cwd() / "benchmarks.json",
     help=(
-        "The path to save the output to. If it is a directory, "
-        "it will save benchmarks.json under it. "
-        "Otherwise, json, yaml, or csv files are supported for output types "
-        "which will be read from the extension for the file path."
+            "The path to save the output to. If it is a directory, "
+            "it will save benchmarks.json under it. "
+            "Otherwise, json, yaml, or csv files are supported for output types "
+            "which will be read from the extension for the file path."
     ),
 )
 @click.option(
@@ -217,8 +219,8 @@ def cli():
     "--output-sampling",
     type=int,
     help=(
-        "The number of samples to save in the output file. "
-        "If None (default), will save all samples."
+            "The number of samples to save in the output file. "
+            "If None (default), will save all samples."
     ),
     default=None,
 )
@@ -229,28 +231,28 @@ def cli():
     help="The random seed to use for benchmarking to ensure reproducibility.",
 )
 def benchmark(
-    target,
-    backend_type,
-    backend_args,
-    model,
-    processor,
-    processor_args,
-    data,
-    data_args,
-    data_sampler,
-    rate_type,
-    rate,
-    max_seconds,
-    max_requests,
-    warmup_percent,
-    cooldown_percent,
-    disable_progress,
-    display_scheduler_stats,
-    disable_console_outputs,
-    output_path,
-    output_extras,
-    output_sampling,
-    random_seed,
+        target,
+        backend_type,
+        backend_args,
+        model,
+        processor,
+        processor_args,
+        data,
+        data_args,
+        data_sampler,
+        rate_type,
+        rate,
+        max_seconds,
+        max_requests,
+        warmup_percent,
+        cooldown_percent,
+        disable_progress,
+        display_scheduler_stats,
+        disable_console_outputs,
+        output_path,
+        output_extras,
+        output_sampling,
+        random_seed,
 ):
     asyncio.run(
         benchmark_generative_text(
@@ -282,12 +284,194 @@ def benchmark(
 
 @cli.command(
     help=(
-        "Print out the available configuration settings that can be set "
-        "through environment variables."
+            "Print out the available configuration settings that can be set "
+            "through environment variables."
     )
 )
 def config():
     print_config()
+
+
+@cli.group(help="Preprocessing utilities for datasets.")
+def preprocess():
+    pass
+
+
+@preprocess.command(
+    help="Convert a dataset to have specific prompt and output token sizes.\n\n"
+         "INPUT_DATA: Path to the input dataset or dataset ID.\n"
+         "OUTPUT_PATH: Directory to save the converted dataset. "
+         "The dataset will be saved as an Arrow dataset (.arrow) inside the directory."
+)
+@click.argument(
+    "input_data",
+    type=str,
+    metavar="INPUT_DATA",
+    required=True,
+)
+@click.argument(
+    "output_path",
+    type=click.Path(file_okay=False, dir_okay=True, writable=True, resolve_path=True),
+    metavar="OUTPUT_PATH",
+    required=True,
+)
+@click.option(
+    "--processor",
+    type=str,
+    required=True,
+    help=(
+            "The processor or tokenizer to use to calculate token counts for statistics "
+            "and synthetic data generation."
+    ),
+)
+@click.option(
+    "--processor-args",
+    default=None,
+    callback=parse_json,
+    help=(
+            "A JSON string containing any arguments to pass to the processor constructor "
+            "as a dict with **kwargs."
+    ),
+)
+@click.option(
+    "--data-args",
+    callback=parse_json,
+    help=(
+            "A JSON string containing any arguments to pass to the dataset creation "
+            "as a dict with **kwargs."
+    ),
+)
+@click.option(
+    "--short-prompt-strategy",
+    type=click.Choice([s.value for s in ShortPromptStrategy]),
+    default=ShortPromptStrategy.IGNORE.value,
+    show_default=True,
+    help="Strategy to handle prompts shorter than the target length. "
+)
+@click.option(
+    "--pad-token",
+    type=str,
+    default=None,
+    help="The token to pad short prompts with when using the 'pad' strategy."
+)
+@click.option(
+    "--prompt-tokens-average",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Average target number of tokens for prompts."
+)
+@click.option(
+    "--prompt-tokens-stdev",
+    type=int,
+    default=None,
+    help="Standard deviation for prompt tokens sampling."
+)
+@click.option(
+    "--prompt-tokens-min",
+    type=int,
+    default=None,
+    help="Minimum number of prompt tokens."
+)
+@click.option(
+    "--prompt-tokens-max",
+    type=int,
+    default=None,
+    help="Maximum number of prompt tokens."
+)
+@click.option(
+    "--prompt-random-seed",
+    type=int,
+    default=42,
+    show_default=True,
+    help="Random seed for prompt token sampling."
+)
+@click.option(
+    "--output-tokens-average",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Average target number of tokens for outputs."
+)
+@click.option(
+    "--output-tokens-stdev",
+    type=int,
+    default=None,
+    help="Standard deviation for output tokens sampling."
+)
+@click.option(
+    "--output-tokens-min",
+    type=int,
+    default=None,
+    help="Minimum number of output tokens."
+)
+@click.option(
+    "--output-tokens-max",
+    type=int,
+    default=None,
+    help="Maximum number of output tokens."
+)
+@click.option(
+    "--output-random-seed",
+    type=int,
+    default=123,
+    show_default=True,
+    help="Random seed for output token sampling."
+)
+@click.option(
+    "--push-to-hub",
+    is_flag=True,
+    help="Set this flag to push the converted dataset to the Hugging Face Hub."
+)
+@click.option(
+    "--hub-dataset-id",
+    type=str,
+    default=None,
+    help="The Hugging Face Hub dataset ID to push to. "
+         "Required if --push-to-hub is used."
+)
+def dataset(
+        input_data,
+        output_path,
+        processor,
+        processor_args,
+        data_args,
+        short_prompt_strategy,
+        pad_token,
+        prompt_tokens_average,
+        prompt_tokens_stdev,
+        prompt_tokens_min,
+        prompt_tokens_max,
+        prompt_random_seed,
+        output_tokens_average,
+        output_tokens_stdev,
+        output_tokens_min,
+        output_tokens_max,
+        output_random_seed,
+        push_to_hub,
+        hub_dataset_id,
+):
+    process_dataset(
+        input_data=input_data,
+        output_path=output_path,
+        processor=processor,
+        processor_args=processor_args,
+        data_args=data_args,
+        short_prompt_strategy=short_prompt_strategy,
+        pad_token=pad_token,
+        prompt_tokens_average=prompt_tokens_average,
+        prompt_tokens_stdev=prompt_tokens_stdev,
+        prompt_tokens_min=prompt_tokens_min,
+        prompt_tokens_max=prompt_tokens_max,
+        prompt_random_seed=prompt_random_seed,
+        output_tokens_average=output_tokens_average,
+        output_tokens_stdev=output_tokens_stdev,
+        output_tokens_min=output_tokens_min,
+        output_tokens_max=output_tokens_max,
+        output_random_seed=output_random_seed,
+        push_to_hub=push_to_hub,
+        hub_dataset_id=hub_dataset_id,
+    )
 
 
 if __name__ == "__main__":

--- a/src/guidellm/preprocess/__init__.py
+++ b/src/guidellm/preprocess/__init__.py
@@ -1,0 +1,6 @@
+from .dataset import process_dataset, ShortPromptStrategy
+
+__all__ = [
+    "process_dataset",
+    "ShortPromptStrategy"
+]

--- a/tests/unit/preprocess/test_dataset.py
+++ b/tests/unit/preprocess/test_dataset.py
@@ -1,0 +1,193 @@
+import os
+from unittest import mock
+from unittest.mock import patch, MagicMock
+
+import pytest
+from datasets import Dataset
+from transformers import PreTrainedTokenizerBase
+
+from guidellm.preprocess.dataset import (
+    handle_ignore_strategy,
+    handle_concatenate_strategy,
+    handle_pad_strategy,
+    process_dataset,
+    push_dataset_to_hub,
+    ShortPromptStrategy,
+    STRATEGY_HANDLERS,
+)
+
+
+@pytest.fixture
+def tokenizer_mock():
+    tokenizer = MagicMock(spec=PreTrainedTokenizerBase)
+    tokenizer.encode.side_effect = lambda x: [1] * len(x)
+    tokenizer.decode.side_effect = lambda x: ''.join(str(item) for item in x)
+    return tokenizer
+
+
+@patch.dict(STRATEGY_HANDLERS, {ShortPromptStrategy.IGNORE: MagicMock(return_value="processed_prompt")})
+@patch(f"{process_dataset.__module__}.guidellm_load_dataset")
+@patch(f"{process_dataset.__module__}.check_load_processor")
+@patch(f"{process_dataset.__module__}.Dataset")
+@patch(f"{process_dataset.__module__}.IntegerRangeSampler")
+def test_strategy_handler_called(
+        mock_sampler, mock_dataset_class, mock_check_processor, mock_load_dataset, tokenizer_mock
+):
+    mock_handler = STRATEGY_HANDLERS[ShortPromptStrategy.IGNORE]
+    mock_dataset = [{"prompt": "abc"}, {"prompt": "def"}]
+    mock_load_dataset.return_value = (mock_dataset, {"prompt_column": "prompt"})
+    mock_check_processor.return_value = tokenizer_mock
+    mock_sampler.side_effect = lambda **kwargs: [10, 10]
+
+    mock_dataset_obj = MagicMock(spec=Dataset)
+    mock_dataset_class.from_list.return_value = mock_dataset_obj
+
+    process_dataset("input", "output_dir", tokenizer_mock, short_prompt_strategy=ShortPromptStrategy.IGNORE)
+
+    assert mock_handler.call_count == 2
+    mock_load_dataset.assert_called_once()
+    mock_check_processor.assert_called_once()
+
+
+def test_handle_ignore_strategy_too_short(tokenizer_mock):
+    result = handle_ignore_strategy("short", 10, tokenizer_mock)
+    assert result is None
+    tokenizer_mock.encode.assert_called_with("short")
+
+
+def test_handle_ignore_strategy_sufficient_length(tokenizer_mock):
+    result = handle_ignore_strategy("long prompt", 5, tokenizer_mock)
+    assert result == "long prompt"
+    tokenizer_mock.encode.assert_called_with("long prompt")
+
+
+def test_handle_concatenate_strategy_enough_prompts(tokenizer_mock):
+    dataset_iter = iter([{"prompt": "longer"}])
+    result = handle_concatenate_strategy("short", 10, dataset_iter, "prompt", tokenizer_mock)
+    assert result == "shortlonger"
+
+
+def test_handle_concatenate_strategy_not_enough_prompts(tokenizer_mock):
+    dataset_iter = iter([])
+    result = handle_concatenate_strategy("short", 10, dataset_iter, "prompt", tokenizer_mock)
+    assert result is None
+
+
+def test_handle_pad_strategy(tokenizer_mock):
+    result = handle_pad_strategy("short", 10, tokenizer_mock, "p")
+    assert result == "shortppppp"
+
+
+@patch(f"{process_dataset.__module__}.Dataset")
+@patch(f"{process_dataset.__module__}.guidellm_load_dataset")
+@patch(f"{process_dataset.__module__}.check_load_processor")
+@patch(f"{process_dataset.__module__}.IntegerRangeSampler")
+def test_process_dataset_non_empty(
+        mock_sampler, mock_check_processor, mock_load_dataset, mock_dataset_class, tokenizer_mock
+):
+    mock_dataset = [{"prompt": "Hello"}, {"prompt": "How are you?"}]
+    mock_load_dataset.return_value = (mock_dataset, {"prompt_column": "prompt"})
+    mock_check_processor.return_value = tokenizer_mock
+    mock_sampler.side_effect = lambda **kwargs: [3, 3, 3]
+
+    mock_dataset_obj = MagicMock(spec=Dataset)
+    mock_dataset_class.from_list.return_value = mock_dataset_obj
+
+    process_dataset("input", "output_dir", tokenizer_mock)
+
+    # Validate
+    mock_load_dataset.assert_called_once()
+    mock_check_processor.assert_called_once()
+    mock_dataset_class.from_list.assert_called_once()
+    mock_dataset_obj.save_to_disk.assert_called_once_with(mock.ANY)
+
+    # Check that generated dataset is correct (extracted from the mock call)
+    args, kwargs = mock_dataset_class.from_list.call_args
+    processed_list = args[0]
+    assert len(processed_list) == 2
+    for item in processed_list:
+        assert "prompt" in item
+        assert "prompt_tokens_count" in item
+        assert "output_tokens_count" in item
+        assert len(tokenizer_mock.encode(item["prompt"])) <= 3
+
+
+@patch(f"{process_dataset.__module__}.Dataset")
+@patch(f"{process_dataset.__module__}.guidellm_load_dataset")
+@patch(f"{process_dataset.__module__}.check_load_processor")
+@patch(f"{process_dataset.__module__}.IntegerRangeSampler")
+def test_process_dataset_empty_after_processing(
+        mock_sampler, mock_check_processor, mock_load_dataset, mock_dataset_class, tokenizer_mock
+):
+    mock_dataset = [{"prompt": ""}]
+    mock_load_dataset.return_value = (mock_dataset, {"prompt_column": "prompt"})
+    mock_check_processor.return_value = tokenizer_mock
+    mock_sampler.side_effect = lambda **kwargs: [10]
+
+    process_dataset("input", "output_dir", tokenizer_mock)
+
+    mock_load_dataset.assert_called_once()
+    mock_check_processor.assert_called_once()
+    mock_dataset_class.from_list.assert_not_called()
+
+
+@patch(f"{process_dataset.__module__}.push_dataset_to_hub")
+@patch(f"{process_dataset.__module__}.Dataset")
+@patch(f"{process_dataset.__module__}.guidellm_load_dataset")
+@patch(f"{process_dataset.__module__}.check_load_processor")
+@patch(f"{process_dataset.__module__}.IntegerRangeSampler")
+def test_process_dataset_push_to_hub_called(
+        mock_sampler, mock_check_processor, mock_load_dataset, mock_dataset_class, mock_push, tokenizer_mock
+):
+    mock_dataset = [{"prompt": "abc"}]
+    mock_load_dataset.return_value = (mock_dataset, {"prompt_column": "prompt"})
+    mock_check_processor.return_value = tokenizer_mock
+    mock_sampler.side_effect = lambda **kwargs: [3]
+
+    mock_dataset_obj = MagicMock(spec=Dataset)
+    mock_dataset_class.from_list.return_value = mock_dataset_obj
+
+    process_dataset("input", "output_dir", tokenizer_mock, push_to_hub=True, hub_dataset_id="id123")
+    mock_push.assert_called_once_with("id123", mock_dataset_obj)
+
+
+@patch(f"{process_dataset.__module__}.push_dataset_to_hub")
+@patch(f"{process_dataset.__module__}.Dataset")
+@patch(f"{process_dataset.__module__}.guidellm_load_dataset")
+@patch(f"{process_dataset.__module__}.check_load_processor")
+@patch(f"{process_dataset.__module__}.IntegerRangeSampler")
+def test_process_dataset_push_to_hub_not_called(
+        mock_sampler, mock_check_processor, mock_load_dataset, mock_dataset_class, mock_push, tokenizer_mock
+):
+    mock_dataset = [{"prompt": "abc"}]
+    mock_load_dataset.return_value = (mock_dataset, {"prompt_column": "prompt"})
+    mock_check_processor.return_value = tokenizer_mock
+    mock_sampler.side_effect = lambda **kwargs: [3]
+
+    mock_dataset_obj = MagicMock(spec=Dataset)
+    mock_dataset_class.from_list.return_value = mock_dataset_obj
+
+    process_dataset("input", "output_dir", tokenizer_mock, push_to_hub=False)
+    mock_push.assert_not_called()
+
+
+def test_push_dataset_to_hub_success():
+    os.environ["HF_TOKEN"] = "token"
+    mock_dataset = MagicMock(spec=Dataset)
+    push_dataset_to_hub("dataset_id", mock_dataset)
+    mock_dataset.push_to_hub.assert_called_once_with("dataset_id", token="token")
+
+
+def test_push_dataset_to_hub_error_no_env():
+    if "HF_TOKEN" in os.environ:
+        del os.environ["HF_TOKEN"]
+    mock_dataset = MagicMock(spec=Dataset)
+    with pytest.raises(ValueError, match="hub_dataset_id and HF_TOKEN"):
+        push_dataset_to_hub("dataset_id", mock_dataset)
+
+
+def test_push_dataset_to_hub_error_no_id():
+    os.environ["HF_TOKEN"] = "token"
+    mock_dataset = MagicMock(spec=Dataset)
+    with pytest.raises(ValueError, match="hub_dataset_id and HF_TOKEN"):
+        push_dataset_to_hub(None, mock_dataset)

--- a/tests/unit/preprocess/test_dataset.py
+++ b/tests/unit/preprocess/test_dataset.py
@@ -95,13 +95,11 @@ def test_process_dataset_non_empty(
 
     process_dataset("input", "output_dir", tokenizer_mock)
 
-    # Validate
     mock_load_dataset.assert_called_once()
     mock_check_processor.assert_called_once()
     mock_dataset_class.from_list.assert_called_once()
     mock_dataset_obj.save_to_disk.assert_called_once_with(mock.ANY)
 
-    # Check that generated dataset is correct (extracted from the mock call)
     args, kwargs = mock_dataset_class.from_list.call_args
     processed_list = args[0]
     assert len(processed_list) == 2


### PR DESCRIPTION
Added a new command - preprocess. This command allows the users to preprocess dataset (from HF, file etc.), and limit the prompts the specific token sizes distribution. The generated dataset is saved to a local file and optionally to HF, and can later be used by GuideLLM benchmark.