### PR TITLE
Restrict rate to only floats

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -34,7 +34,7 @@ def parse_number_str(ctx, param, value):  # noqa: ARG001
         return [float(val) for val in values]
     except ValueError as err:
         raise click.BadParameter(
-            f"{param.name} must be a number or comma-separated list of numbers."
+            f"{param.name} must be a floating-point number or comma-separated list of floating-point numbers."
         ) from err
 
 

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -31,7 +31,7 @@ def parse_number_str(ctx, param, value):  # noqa: ARG001
     values = value.split(",") if "," in value else [value]
 
     try:
-        return [int(val) if val.isdigit() else float(val) for val in values]
+        return [float(val) for val in values]
     except ValueError as err:
         raise click.BadParameter(
             f"{param.name} must be a number or comma-separated list of numbers."

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -34,7 +34,7 @@ def parse_number_str(ctx, param, value):  # noqa: ARG001
         return [float(val) for val in values]
     except ValueError as err:
         raise click.BadParameter(
-            f"{param.name} must be a floating-point number or comma-separated list of floating-point numbers."
+            f"{param.name} must be a number or comma-separated list of numbers."
         ) from err
 
 

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -38,7 +38,7 @@ async def benchmark_generative_text(
     data_args: Optional[dict[str, Any]],
     data_sampler: Optional[Literal["random"]],
     rate_type: Union[StrategyType, ProfileType],
-    rate: Optional[Union[int, float, list[Union[int, float]]]],
+    rate: Optional[Union[float, list[float]]],
     max_seconds: Optional[float],
     max_requests: Optional[int],
     warmup_percent: Optional[float],


### PR DESCRIPTION
We already support casting floats to int so to simplify the arg code and solve an issue with older pythons just treat all input as floats.

Fixes #163 