### PR TITLE
Feat/max error rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The `guidellm benchmark` command is used to run benchmarks against a generative 
 
 - `--max-requests`: Sets the maximum number of requests for each benchmark run. If not provided, the benchmark will run until `--max-seconds` is reached or the dataset is exhausted.
 
-- `--max-error-rate`: The maximum error rate after which a benchmark will stop. Applicable only for finite deterministic scenarios i.e `rate_type` is `constant` and `--max-seconds` exists OR `--max-requests` exists OR the dataset is finite. If `--max-error-rate` is `None`, benchmarks will continue regardless of error rate.
+- `--max-error-rate`: The maximum error rate after which a benchmark will stop. Applicable only for finite deterministic scenarios i.e `rate_type` is `constant` and `--max-seconds` exists OR `--max-requests` exists OR the dataset is finite. If `--max-error-rate` is `None` or not applicable, benchmarks will continue regardless of error rate.
 
 - `--warmup-percent`: Specifies the percentage of the benchmark to treat as a warmup phase. Requests during this phase are excluded from the final results.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The `guidellm benchmark` command is used to run benchmarks against a generative 
 
 - `--max-requests`: Sets the maximum number of requests for each benchmark run. If not provided, the benchmark will run until `--max-seconds` is reached or the dataset is exhausted.
 
+- `--max-error-rate`: The maximum error rate after which a benchmark will stop. Applicable only for finite deterministic scenarios i.e `rate_type` is `constant` and `--max-seconds` exists OR `--max-requests` exists OR the dataset is finite. If `--max-error-rate` is `None`, benchmarks will continue regardless of error rate.
+
 - `--warmup-percent`: Specifies the percentage of the benchmark to treat as a warmup phase. Requests during this phase are excluded from the final results.
 
 - `--cooldown-percent`: Specifies the percentage of the benchmark to treat as a cooldown phase. Requests during this phase are excluded from the final results.

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -164,6 +164,16 @@ def cli():
     ),
 )
 @click.option(
+    "--max-error-rate",
+    type=float,
+    help=(
+        "The maximum error rate after which a benchmark will stop. "
+        "Applicable only for finite deterministic scenarios i.e rate_type is 'constant' and 'max_seconds' exists OR "
+        "'max_requests' exists OR the dataset is finite. "
+        "If None, benchmarks will continue regardless of error rate."
+    ),
+)
+@click.option(
     "--warmup-percent",
     type=float,
     default=None,
@@ -242,6 +252,7 @@ def benchmark(
     rate,
     max_seconds,
     max_requests,
+    max_error_rate,
     warmup_percent,
     cooldown_percent,
     disable_progress,
@@ -267,6 +278,7 @@ def benchmark(
             rate=rate,
             max_seconds=max_seconds,
             max_requests=max_requests,
+            max_error_rate=max_error_rate,
             warmup_percent=warmup_percent,
             cooldown_percent=cooldown_percent,
             show_progress=not disable_progress,

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -168,7 +168,8 @@ def cli():
     type=float,
     help=(
         "The maximum error rate after which a benchmark will stop. "
-        "Applicable only for finite deterministic scenarios i.e rate_type is 'constant' and 'max_seconds' exists OR "
+        "Applicable only for finite deterministic scenarios i.e "
+        "rate_type is 'constant' and 'max_seconds' exists OR "
         "'max_requests' exists OR the dataset is finite. "
         "If None or not applicable, benchmarks will continue regardless of error rate."
     ),

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -170,7 +170,7 @@ def cli():
         "The maximum error rate after which a benchmark will stop. "
         "Applicable only for finite deterministic scenarios i.e rate_type is 'constant' and 'max_seconds' exists OR "
         "'max_requests' exists OR the dataset is finite. "
-        "If None, benchmarks will continue regardless of error rate."
+        "If None or not applicable, benchmarks will continue regardless of error rate."
     ),
 )
 @click.option(

--- a/src/guidellm/benchmark/aggregator.py
+++ b/src/guidellm/benchmark/aggregator.py
@@ -599,8 +599,8 @@ class GenerativeBenchmarkAggregator(
         and return the compiled object.
         """
         successful, incomplete, errored = self._compile_results()
-        error_rate = self.requests_stats.totals.errored.total / \
-            (self.requests_stats.totals.successful.total + self.requests_stats.totals.errored.total)
+
+        error_rate = self._calculate_error_rate()
 
         return GenerativeBenchmark.from_stats(
             run_id=self.run_id,
@@ -633,6 +633,12 @@ class GenerativeBenchmarkAggregator(
             requests_loader=self.request_loader_description,
             extras=self.extras,
         )
+
+    def _calculate_error_rate(self) -> float:
+        total_successful = self.requests_stats.totals.successful.total
+        total_errored = self.requests_stats.totals.errored.total
+        total_sent = total_errored + total_successful
+        return total_errored / total_sent
 
     def _compile_results(
         self,

--- a/src/guidellm/benchmark/aggregator.py
+++ b/src/guidellm/benchmark/aggregator.py
@@ -600,7 +600,7 @@ class GenerativeBenchmarkAggregator(
         """
         successful, incomplete, errored = self._compile_results()
         error_rate = self.requests_stats.totals.errored.total / \
-            (self.requests_stats.totals.successful + self.requests_stats.totals.errored.total)
+            (self.requests_stats.totals.successful.total + self.requests_stats.totals.errored.total)
 
         return GenerativeBenchmark.from_stats(
             run_id=self.run_id,

--- a/src/guidellm/benchmark/aggregator.py
+++ b/src/guidellm/benchmark/aggregator.py
@@ -599,6 +599,8 @@ class GenerativeBenchmarkAggregator(
         and return the compiled object.
         """
         successful, incomplete, errored = self._compile_results()
+        error_rate = self.requests_stats.totals.errored.total / \
+            (self.requests_stats.totals.successful + self.requests_stats.totals.errored.total)
 
         return GenerativeBenchmark.from_stats(
             run_id=self.run_id,
@@ -625,6 +627,7 @@ class GenerativeBenchmarkAggregator(
                 request_start_time_targeted_delay_avg=self.requests_stats.request_start_time_targeted_delay.mean,
                 request_time_delay_avg=self.requests_stats.request_time_delay.mean,
                 request_time_avg=self.requests_stats.request_time.mean,
+                error_rate=error_rate,
             ),
             worker=self.worker_description,
             requests_loader=self.request_loader_description,

--- a/src/guidellm/benchmark/benchmark.py
+++ b/src/guidellm/benchmark/benchmark.py
@@ -90,6 +90,9 @@ class BenchmarkArgs(StandardBaseModel):
     max_duration: Optional[float] = Field(
         description="The maximum duration in seconds to run this benchmark, if any."
     )
+    max_error_rate: Optional[float] = Field(
+        description="Maximum error rate after which a benchmark will stop."
+    )
     warmup_number: Optional[int] = Field(
         description=(
             "The number of requests to run for the warmup phase of this benchmark, "
@@ -211,6 +214,12 @@ class BenchmarkRunStats(StandardBaseModel):
             "The average time spent processing all requests in the benchmark run. "
             "This is the time from when the actual request was started to when "
             "it was completed."
+        )
+    )
+    error_rate: float = Field(
+        description=(
+            "The number of errored requests divided by the number of errored requests. This can be higher "
+            "than max_error_rate (if applicable) cause it does not take into account incomplete requests."
         )
     )
 

--- a/src/guidellm/benchmark/benchmark.py
+++ b/src/guidellm/benchmark/benchmark.py
@@ -218,8 +218,10 @@ class BenchmarkRunStats(StandardBaseModel):
     )
     error_rate: float = Field(
         description=(
-            "The number of errored requests divided by the number of errored requests. This can be higher "
-            "than max_error_rate (if applicable) cause it does not take into account incomplete requests."
+            "The number of errored requests divided by the number "
+            "of errored requests. This can be higher than max_error_rate "
+            "(if applicable) cause it does not take into "
+            "account incomplete requests."
         )
     )
 

--- a/src/guidellm/benchmark/benchmark.py
+++ b/src/guidellm/benchmark/benchmark.py
@@ -710,7 +710,7 @@ class GenerativeBenchmark(Benchmark):
             *["incomplete"] * len(incomplete),  # type: ignore[list-item]
             *["error"] * len(errored),  # type: ignore[list-item]
         ]
-        start_time = min(req.start_time for req in total) # ToDo: Fix if total is empty
+        start_time = min(req.start_time for req in total)
         end_time = max(req.end_time for req in total)
 
         total_with_prompt, total_types_with_prompt = (

--- a/src/guidellm/benchmark/benchmark.py
+++ b/src/guidellm/benchmark/benchmark.py
@@ -701,7 +701,7 @@ class GenerativeBenchmark(Benchmark):
             *["incomplete"] * len(incomplete),  # type: ignore[list-item]
             *["error"] * len(errored),  # type: ignore[list-item]
         ]
-        start_time = min(req.start_time for req in total)
+        start_time = min(req.start_time for req in total) # ToDo: Fix if total is empty
         end_time = max(req.end_time for req in total)
 
         total_with_prompt, total_types_with_prompt = (

--- a/src/guidellm/benchmark/benchmarker.py
+++ b/src/guidellm/benchmark/benchmarker.py
@@ -74,6 +74,11 @@ class BenchmarkerStrategyLimits(StandardBaseModel):
         description="Maximum duration (in seconds) to process requests per strategy.",
         ge=0,
     )
+    max_error_rate: Optional[float] = Field(
+        description="Maximum error rate after which a sync benchmark will stop",
+        ge=0,
+        le=1,
+    )
     warmup_percent_per_strategy: Optional[float] = Field(
         description="Percentage of requests to use for warmup.",
         ge=0,
@@ -148,6 +153,7 @@ class Benchmarker(Generic[AggregatorT, BenchmarkT, RequestT, ResponseT], ABC):
         profile: Profile,
         max_number_per_strategy: Optional[int],
         max_duration_per_strategy: Optional[float],
+        max_error_rate: Optional[float],
         warmup_percent_per_strategy: Optional[float],
         cooldown_percent_per_strategy: Optional[float],
     ) -> AsyncGenerator[
@@ -162,6 +168,7 @@ class Benchmarker(Generic[AggregatorT, BenchmarkT, RequestT, ResponseT], ABC):
             requests_loader_size=requests_loader_size,
             max_number_per_strategy=max_number_per_strategy,
             max_duration_per_strategy=max_duration_per_strategy,
+            max_error_rate=max_error_rate,
             warmup_percent_per_strategy=warmup_percent_per_strategy,
             cooldown_percent_per_strategy=cooldown_percent_per_strategy,
         )
@@ -196,6 +203,7 @@ class Benchmarker(Generic[AggregatorT, BenchmarkT, RequestT, ResponseT], ABC):
                 scheduling_strategy=scheduling_strategy,
                 max_number=max_number_per_strategy,
                 max_duration=max_duration_per_strategy,
+                max_error_rate=max_error_rate,
             ):
                 if result.type_ == "run_start":
                     yield BenchmarkerResult(
@@ -321,6 +329,7 @@ class GenerativeBenchmarker(
                 strategy=strategy,
                 max_number=limits.max_number,
                 max_duration=limits.max_duration,
+                max_error_rate=limits.max_error_rate,
                 warmup_number=limits.warmup_number,
                 warmup_duration=limits.warmup_duration,
                 cooldown_number=limits.cooldown_number,

--- a/src/guidellm/benchmark/benchmarker.py
+++ b/src/guidellm/benchmark/benchmarker.py
@@ -75,7 +75,7 @@ class BenchmarkerStrategyLimits(StandardBaseModel):
         ge=0,
     )
     max_error_rate: Optional[float] = Field(
-        description="Maximum error rate after which a sync benchmark will stop",
+        description="Maximum error rate after which a benchmark will stop",
         ge=0,
         le=1,
     )

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -41,6 +41,7 @@ async def benchmark_generative_text(
     rate: Optional[Union[int, float, list[Union[int, float]]]],
     max_seconds: Optional[float],
     max_requests: Optional[int],
+    max_error_rate: Optional[float],
     warmup_percent: Optional[float],
     cooldown_percent: Optional[float],
     show_progress: bool,
@@ -107,6 +108,7 @@ async def benchmark_generative_text(
         profile=profile,
         max_number_per_strategy=max_requests,
         max_duration_per_strategy=max_seconds,
+        max_error_rate=max_error_rate,
         warmup_percent_per_strategy=warmup_percent,
         cooldown_percent_per_strategy=cooldown_percent,
     ):

--- a/src/guidellm/benchmark/output.py
+++ b/src/guidellm/benchmark/output.py
@@ -419,6 +419,7 @@ class GenerativeBenchmarksConsole:
             {
                 "max_number": args.max_number,
                 "max_duration": args.max_duration,
+                "max_error_rate": args.max_error_rate,
                 "warmup_number": args.warmup_number,
                 "warmup_duration": args.warmup_duration,
                 "cooldown_number": args.cooldown_number,

--- a/src/guidellm/request/__init__.py
+++ b/src/guidellm/request/__init__.py
@@ -1,6 +1,7 @@
 from .loader import (
     GenerativeRequestLoader,
     GenerativeRequestLoaderDescription,
+    GetInfiniteDatasetLengthError,
     RequestLoader,
     RequestLoaderDescription,
 )
@@ -10,6 +11,7 @@ __all__ = [
     "GenerationRequest",
     "GenerativeRequestLoader",
     "GenerativeRequestLoaderDescription",
+    "GetInfiniteDatasetLengthError",
     "RequestLoader",
     "RequestLoaderDescription",
 ]

--- a/src/guidellm/request/loader.py
+++ b/src/guidellm/request/loader.py
@@ -21,7 +21,12 @@ __all__ = [
     "GenerativeRequestLoaderDescription",
     "RequestLoader",
     "RequestLoaderDescription",
+    "InfiniteDatasetError"
 ]
+
+
+class InfiniteDatasetError(Exception):
+    pass
 
 
 class RequestLoaderDescription(StandardBaseModel):
@@ -120,7 +125,8 @@ class GenerativeRequestLoader(RequestLoader):
         if self.iter_type == "finite":
             return self.num_unique_items()
 
-        raise ValueError(f"Unable to determine length of dataset: {self.data}")
+        assert self.iter_type == "infinite"
+        raise InfiniteDatasetError(f"Dataset {self.data} is infinite and thus unable to determine length")
 
     @property
     def description(self) -> GenerativeRequestLoaderDescription:

--- a/src/guidellm/request/loader.py
+++ b/src/guidellm/request/loader.py
@@ -19,13 +19,13 @@ from guidellm.request.request import GenerationRequest
 __all__ = [
     "GenerativeRequestLoader",
     "GenerativeRequestLoaderDescription",
+    "GetInfiniteDatasetLengthError",
     "RequestLoader",
     "RequestLoaderDescription",
-    "InfiniteDatasetError"
 ]
 
 
-class InfiniteDatasetError(Exception):
+class GetInfiniteDatasetLengthError(Exception):
     pass
 
 
@@ -125,8 +125,11 @@ class GenerativeRequestLoader(RequestLoader):
         if self.iter_type == "finite":
             return self.num_unique_items()
 
-        assert self.iter_type == "infinite"
-        raise InfiniteDatasetError(f"Dataset {self.data} is infinite and thus unable to determine length")
+        if self.iter_type != "infinite":
+            raise ValueError(f"Invalid iter_type {self.iter_type}")
+        raise GetInfiniteDatasetLengthError(f"Dataset {self.data} is "
+                                            f"infinite and thus "
+                                            f"unable to determine length")
 
     @property
     def description(self) -> GenerativeRequestLoaderDescription:

--- a/src/guidellm/scheduler/result.py
+++ b/src/guidellm/scheduler/result.py
@@ -43,7 +43,7 @@ class SchedulerRunInfo(StandardBaseModel):
 
     start_time: float
     end_time: float
-    end_number: float  # ToDo: Rename to max_requests & change to int (check all references before)
+    end_number: float
     processes: int
     strategy: SchedulingStrategy
     max_error_rate: Optional[float] = None

--- a/src/guidellm/scheduler/result.py
+++ b/src/guidellm/scheduler/result.py
@@ -46,7 +46,7 @@ class SchedulerRunInfo(StandardBaseModel):
     end_number: float  # ToDo: Rename to max_requests & change to int (check all references before)
     processes: int
     strategy: SchedulingStrategy
-    max_error_rate: float
+    max_error_rate: Optional[float] = None
 
     created_requests: int = 0
     queued_requests: int = 0

--- a/src/guidellm/scheduler/result.py
+++ b/src/guidellm/scheduler/result.py
@@ -43,7 +43,7 @@ class SchedulerRunInfo(StandardBaseModel):
 
     start_time: float
     end_time: float
-    end_number: float
+    end_number: float  # ToDo: Rename to max_requests & change to int (check all references before)
     processes: int
     strategy: SchedulingStrategy
     max_error_rate: float

--- a/src/guidellm/scheduler/result.py
+++ b/src/guidellm/scheduler/result.py
@@ -46,12 +46,14 @@ class SchedulerRunInfo(StandardBaseModel):
     end_number: float
     processes: int
     strategy: SchedulingStrategy
+    max_error_rate: float
 
     created_requests: int = 0
     queued_requests: int = 0
     scheduled_requests: int = 0
     processing_requests: int = 0
     completed_requests: int = 0
+    errored_requests: int = 0
 
 
 class SchedulerRequestInfo(StandardBaseModel):

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -64,6 +64,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
 
         self.worker = worker
         self.request_loader = request_loader
+        self.error_rate: Optional[float] = None
 
     async def run(
         self,
@@ -117,6 +118,8 @@ class Scheduler(Generic[RequestT, ResponseT]):
         if max_error_rate is not None and (max_error_rate < 0 or max_error_rate > 1):
             raise ValueError(f"Invalid max_error_rate: {max_error_rate}")
 
+        shutdown_event = multiprocessing.Event()
+
         with (
             multiprocessing.Manager() as manager,
             ProcessPoolExecutor(
@@ -124,7 +127,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
             ) as executor,
         ):
             requests_iter: Optional[Iterator[Any]] = None
-            futures, requests_queue, responses_queue, shutdown_event = await self._start_processes(
+            futures, requests_queue, responses_queue = await self._start_processes(
                 manager, executor, scheduling_strategy
             )
             run_info, requests_iter, times_iter = self._run_setup(
@@ -164,9 +167,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
                     )
                     if iter_result is not None:
                         if self._is_max_error_rate_reached(iter_result.run_info):
-                            logger.info(f"Max_error rate of ({iter_result.run_info.max_error_rate}) reached, sending "
-                                        f"shutdown signal")
-                            shutdown_event.set()
+                            logger.info(f"Max_error rate of ({iter_result.run_info.max_error_rate}) reached!")
                         yield iter_result
 
                     # yield control to the event loop
@@ -190,10 +191,8 @@ class Scheduler(Generic[RequestT, ResponseT]):
         list[asyncio.Future],
         multiprocessing.Queue,
         multiprocessing.Queue,
-        multiprocessing.Event
     ]:
         await self.worker.prepare_multiprocessing()
-        shutdown_event = multiprocessing.Event()
         requests_queue = manager.Queue(
             maxsize=scheduling_strategy.queued_requests_limit
         )
@@ -230,7 +229,6 @@ class Scheduler(Generic[RequestT, ResponseT]):
                         requests_queue,
                         responses_queue,
                         id_,
-                        shutdown_event,
                     )
                 )
             elif scheduling_strategy.processing_mode == "async":
@@ -242,7 +240,6 @@ class Scheduler(Generic[RequestT, ResponseT]):
                         responses_queue,
                         requests_limit,
                         id_,
-                        shutdown_event,
                     )
                 )
             else:
@@ -253,7 +250,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
 
         await asyncio.sleep(0.1)  # give time for processes to start
 
-        return futures, requests_queue, responses_queue, shutdown_event
+        return futures, requests_queue, responses_queue
 
     def _run_setup(
         self,
@@ -388,7 +385,8 @@ class Scheduler(Generic[RequestT, ResponseT]):
             )
         raise ValueError(f"Invalid process response type: {process_response}")
 
-    def _is_max_error_rate_reached(self, run_info: SchedulerRunInfo) -> bool:
+    @staticmethod
+    def _is_max_error_rate_reached(run_info: SchedulerRunInfo) -> bool:
         current_error_rate = run_info.errored_requests / run_info.end_number
         return current_error_rate > run_info.max_error_rate
 

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -109,7 +109,10 @@ class Scheduler(Generic[RequestT, ResponseT]):
             Each SchedulerResult object contains information about the request,
             the response, and the run information.
         """
-        self._validate_scheduler_params(scheduling_strategy, max_duration, max_error_rate, max_number)
+        self._validate_scheduler_params(scheduling_strategy,
+                                        max_duration,
+                                        max_error_rate,
+                                        max_number)
 
         with (
             multiprocessing.Manager() as manager,
@@ -163,8 +166,8 @@ class Scheduler(Generic[RequestT, ResponseT]):
                     )
                     if iter_result is not None:
                         if iter_result.request_info.errored \
-                            and not iter_result.request_info.canceled \
-                                and self._is_max_error_rate_reached(iter_result.run_info):
+                        and not iter_result.request_info.canceled \
+                        and self._is_max_error_rate_reached(iter_result.run_info):
                             shutdown_event.set()
                             max_error_rate_reached = True
                             logger.info(f"Max error rate of "

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -102,7 +102,8 @@ class Scheduler(Generic[RequestT, ResponseT]):
             If None, then no limit is set and either the iterator must be exhaustible
             or the max_number must be set.
         :param max_error_rate: The maximum error rate after which the scheduler shuts down.
-            If not provided a default of 5% i.e 0.05 is used.
+            Only applicable in benchmarks with finite deterministic number of requests.
+            If None or not applicable then scheduler will continue regardless of errors.
         :return: An asynchronous generator that yields SchedulerResult objects.
             Each SchedulerResult object contains information about the request,
             the response, and the run information.
@@ -130,7 +131,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
                 manager, executor, scheduling_strategy, max_error_rate is not None
             )
             if shutdown_event:
-                assert not shutdown_event.is_set()
+                assert not shutdown_event.is_set(),  "shutdown_event is set before starting scheduling"
             run_info, requests_iter, times_iter = self._run_setup(
                 futures, scheduling_strategy, max_number, max_duration, max_error_rate
             )

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -277,7 +277,7 @@ class Scheduler(Generic[RequestT, ResponseT]):
         start_time = time.time()
         times_iter = iter(scheduling_strategy.request_times())
         end_time = time.time() + (max_duration or math.inf)
-        end_number = self._determine_total_requests_count(scheduling_strategy, max_duration, max_error_rate, max_number)
+        end_number = self._determine_total_requests_count(scheduling_strategy, max_duration, max_number)
 
         if end_number == math.inf and max_error_rate is not None:
             logger.warning("max_error_rate will be ignored because end_number can not be determined.")
@@ -303,7 +303,6 @@ class Scheduler(Generic[RequestT, ResponseT]):
             self,
             scheduling_strategy: SchedulingStrategy,
             max_duration: Optional[float],
-            max_error_rate: Optional[float],
             max_number: Optional[int],
     ) -> int:
         end_number = max_number or math.inf
@@ -318,10 +317,6 @@ class Scheduler(Generic[RequestT, ResponseT]):
                 if total_requests_in_max_duration < end_number:
                     assert total_requests_in_max_duration > 0
                     end_number = total_requests_in_max_duration
-            else:
-                if max_error_rate:
-                    logger.warning()
-                raise
         except Exception:
             pass
         return end_number

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -315,13 +315,15 @@ class Scheduler(Generic[RequestT, ResponseT]):
             iter_length = len(self.request_loader)  # type: ignore[arg-type]
             if 0 < iter_length < end_number:
                 end_number = iter_length
-        except InfiniteDatasetError:  # noqa: BLE001, S110
+        except InfiniteDatasetError:
+            # Only when RPS is constant and duration is capped we can determine the total
+            # amount of requests that are supposed to be sent
             if scheduling_strategy.type_ == "constant" and max_duration is not None:
                 total_requests_in_max_duration = int(scheduling_strategy.rate * max_duration)
                 if total_requests_in_max_duration < end_number:
                     assert total_requests_in_max_duration > 0
                     end_number = total_requests_in_max_duration
-        except Exception:
+        except Exception:  # noqa: BLE001, S110
             pass
         return end_number
 

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -121,13 +121,9 @@ class RequestsWorker(ABC, Generic[RequestT, ResponseT]):
         ...
 
     async def get_request(
-        self, requests_queue: multiprocessing.Queue, shutdown_event: multiprocessing.Event, shutdonen_check_
+        self, requests_queue: multiprocessing.Queue
     ) -> Optional[WorkerProcessRequest[RequestT]]:
-        def _get_queue_intermittently(request_queue: multiprocessing.Queue, shutdown_event):
-            try:
-                
-
-        return await asyncio.to_thread(_get_queue_intermittently())  # type: ignore[attr-defined]
+        return await asyncio.to_thread(requests_queue.get)  # type: ignore[attr-defined]
 
     async def send_result(
         self,
@@ -226,7 +222,6 @@ class RequestsWorker(ABC, Generic[RequestT, ResponseT]):
         results_queue: multiprocessing.Queue,
         max_concurrency: int,
         process_id: int,
-        shutdown_event: multiprocessing.Event,
     ):
         async def _process_runner():
             pending = asyncio.Semaphore(max_concurrency)

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -121,9 +121,13 @@ class RequestsWorker(ABC, Generic[RequestT, ResponseT]):
         ...
 
     async def get_request(
-        self, requests_queue: multiprocessing.Queue
+        self, requests_queue: multiprocessing.Queue, shutdown_event: multiprocessing.Event, shutdonen_check_
     ) -> Optional[WorkerProcessRequest[RequestT]]:
-        return await asyncio.to_thread(requests_queue.get)  # type: ignore[attr-defined]
+        def _get_queue_intermittently(request_queue: multiprocessing.Queue, shutdown_event):
+            try:
+                
+
+        return await asyncio.to_thread(_get_queue_intermittently())  # type: ignore[attr-defined]
 
     async def send_result(
         self,
@@ -222,6 +226,7 @@ class RequestsWorker(ABC, Generic[RequestT, ResponseT]):
         results_queue: multiprocessing.Queue,
         max_concurrency: int,
         process_id: int,
+        shutdown_event: multiprocessing.Event,
     ):
         async def _process_runner():
             pending = asyncio.Semaphore(max_concurrency)

--- a/tests/unit/benchmark/test_output.py
+++ b/tests/unit/benchmark/test_output.py
@@ -113,7 +113,7 @@ def test_console_benchmarks_args_str():
     mock_benchmark = mock_generative_benchmark()
     console.benchmarks = [mock_benchmark]
     assert console.benchmarks_args_str == (
-        "max_number=None, max_duration=10.0, warmup_number=None, "
+        "max_number=None, max_duration=10.0, max_error_rate=0.05, warmup_number=None, "
         "warmup_duration=None, cooldown_number=None, cooldown_duration=None"
     )
 

--- a/tests/unit/mock_benchmark.py
+++ b/tests/unit/mock_benchmark.py
@@ -221,6 +221,7 @@ def mock_generative_benchmark() -> GenerativeBenchmark:
             strategy=SynchronousStrategy(),
             max_number=None,
             max_duration=10.0,
+            max_error_rate=0.05,
             warmup_number=None,
             warmup_duration=None,
             cooldown_number=None,
@@ -245,6 +246,7 @@ def mock_generative_benchmark() -> GenerativeBenchmark:
             request_start_time_targeted_delay_avg=1.2827096836907523,
             request_time_delay_avg=0.0004316908972603934,
             request_time_avg=1.426228676523481,
+            error_rate=0.345346,
         ),
         worker=GenerativeRequestsWorkerDescription(
             backend_type="openai_http",


### PR DESCRIPTION
Addressing this issue:
https://github.com/neuralmagic/guidellm/issues/105

`--max-error-rate` flag was added. 
It is only applicable in either or the the following scenarios:
1) Fixed length dataset
2) `max_requests` is set
2) `rate_type` is `constant` and `max_duration` is set