### PR TITLE
fix links check fail, remove speculators from docs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,22 +37,6 @@ jobs:
       - name: Run quality checks
         run: tox -e types
 
-  link-checks:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run link checks
-        run: tox -e links
-
   precommit-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,22 +38,6 @@ jobs:
       - name: Run quality checks
         run: tox -e types
 
-  link-checks:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run link checks
-        run: tox -e links
-
   precommit-checks:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ You can either clone the repository directly or fork it if you plan to contribut
    cd guidellm
    ```
 
-For detailed instructions on setting up your development environment, please refer to the [DEVELOPING.md](https://github.com/neuralmagic/speculators/blob/main/DEVELOPING.md) file. It includes step-by-step guidance on:
+For detailed instructions on setting up your development environment, please refer to the [DEVELOPING.md](https://github.com/neuralmagic/guidellm/blob/main/DEVELOPING.md) file. It includes step-by-step guidance on:
 
 - Installing dependencies
 - Running tests
@@ -114,8 +114,8 @@ If you encounter a bug or have a feature request, please open an issue on GitHub
 
 ## Community Standards
 
-We are committed to fostering a welcoming and inclusive community. Please read and adhere to our [Code of Conduct](https://github.com/neuralmagic/speculators/blob/main/CODE_OF_CONDUCT.md).
+We are committed to fostering a welcoming and inclusive community. Please read and adhere to our [Code of Conduct](https://github.com/neuralmagic/guidellm/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing to Speculators, you agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/neuralmagic/speculators/blob/main/LICENSE).
+By contributing to GuideLLM, you agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/neuralmagic/guidellm/blob/main/LICENSE).

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
-# Developing for Speculators
+# Developing for GuideLLM
 
-Thank you for your interest in contributing to Speculators! This document provides detailed instructions for setting up your development environment, implementing changes, and adhering to the project's best practices. Your contributions help us grow and improve this project.
+Thank you for your interest in contributing to GuideLLM! This document provides detailed instructions for setting up your development environment, implementing changes, and adhering to the project's best practices. Your contributions help us grow and improve this project.
 
 ## Setting Up Your Development Environment
 
@@ -142,7 +142,7 @@ tox
 To ensure your changes are covered by tests, run:
 
 ```bash
-tox -e test-unit -- --cov=speculators --cov-report=html
+tox -e test-unit -- --cov=guidellm --cov-report=html
 ```
 
 Review the coverage report to confirm that your new code is adequately tested.
@@ -181,7 +181,7 @@ Review the coverage report to confirm that your new code is adequately tested.
 
 ## Additional Resources
 
-- [CONTRIBUTING.md](https://github.com/neuralmagic/speculators/blob/main/CONTRIBUTING.md): Guidelines for contributing to the project.
-- [CODE_OF_CONDUCT.md](https://github.com/neuralmagic/speculators/blob/main/CODE_OF_CONDUCT.md): Our expectations for community behavior.
-- [tox.ini](https://github.com/neuralmagic/speculators/blob/main/tox.ini): Configuration for Tox environments.
-- [.pre-commit-config.yaml](https://github.com/neuralmagic/speculators/blob/main/.pre-commit-config.yaml): Configuration for pre-commit hooks.
+- [CONTRIBUTING.md](https://github.com/neuralmagic/guidellm/blob/main/CONTRIBUTING.md): Guidelines for contributing to the project.
+- [CODE_OF_CONDUCT.md](https://github.com/neuralmagic/guidellm/blob/main/CODE_OF_CONDUCT.md): Our expectations for community behavior.
+- [tox.ini](https://github.com/neuralmagic/guidellm/blob/main/tox.ini): Configuration for Tox environments.
+- [.pre-commit-config.yaml](https://github.com/neuralmagic/guidellm/blob/main/.pre-commit-config.yaml): Configuration for pre-commit hooks.

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ description = Run link checks for root and docs markdown files
 deps =
     .[dev]
 commands =
-    mkdocs-linkcheck ./ --exclude 'https://github\.com/.*/blob/.*'
-    mkdocs-linkcheck docs/ --exclude 'https://github\.com/.*/blob/.*'
+    mkdocs-linkcheck ./
+    mkdocs-linkcheck docs/
 
 
 [testenv:build]

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ description = Run link checks for root and docs markdown files
 deps =
     .[dev]
 commands =
-    mkdocs-linkcheck ./
-    mkdocs-linkcheck docs/
+    mkdocs-linkcheck ./ --exclude 'https://github\.com/.*/blob/.+\.md'
+    mkdocs-linkcheck docs/ --exclude 'https://github\.com/.*/blob/.+\.md'
 
 
 [testenv:build]

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ description = Run link checks for root and docs markdown files
 deps =
     .[dev]
 commands =
-    mkdocs-linkcheck ./ --exclude 'https://github\.com/.*/blob/.+\.md'
-    mkdocs-linkcheck docs/ --exclude 'https://github\.com/.*/blob/.+\.md'
+    mkdocs-linkcheck ./ --exclude 'https://github\.com/.*/blob/.*'
+    mkdocs-linkcheck docs/ --exclude 'https://github\.com/.*/blob/.*'
 
 
 [testenv:build]


### PR DESCRIPTION
We are getting link-check fails on the github rich display links. Not sure what the desired solution is but this gets the check passing by ignoring links like that.

Also we have what look to be some pasted doc remnants from the speculators repo so I changed everything saying speculators to guidellm