### PR TITLE
Fix checkout target for pull request workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,6 +12,8 @@ jobs:
         python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -28,6 +30,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install dependencies
         run: npm ci
@@ -42,6 +46,8 @@ jobs:
         python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -58,6 +64,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install dependencies
         run: npm ci
@@ -72,6 +80,8 @@ jobs:
         python: ["3.9"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -88,6 +98,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install dependencies
         run: npm ci
@@ -102,6 +114,8 @@ jobs:
         python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -132,6 +146,8 @@ jobs:
         python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -148,6 +164,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install dependencies
         run: npm ci
@@ -165,6 +183,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
when using `pull_request_target:` the default ref is main so all checks are run from the main branch rather than the PR. This re-targets all checkouts to a generated `merge_commit` which matches the behavior of `pull_request:`. ([ref](https://github.com/actions/checkout/issues/518))