### PR TITLE
Revert "Features/add tooltip to line chart"

### DIFF
--- a/src/ui/lib/components/Charts/MetricLine/MetricLine.component.tsx
+++ b/src/ui/lib/components/Charts/MetricLine/MetricLine.component.tsx
@@ -1,6 +1,5 @@
-import { Typography, useTheme } from '@mui/material';
-import { PointTooltipProps, ResponsiveLine } from '@nivo/line';
-import { BasicTooltip } from '@nivo/tooltip';
+import { useTheme } from '@mui/material';
+import { ResponsiveLine } from '@nivo/line';
 import React, { FC } from 'react';
 
 import { useColor } from '@/lib/hooks/useColor';
@@ -50,30 +49,11 @@ export const Component: FC<MetricLineProps> = ({
       reverse: false,
     };
   }
-  type PointTooltipPropsWithLabel = PointTooltipProps & {
-    point: {
-      data: {
-        label: string;
-      };
-    };
-  };
 
   return (
     <ResponsiveLine
       curve="monotoneX"
       data={data}
-      tooltip={(point) => (
-        <BasicTooltip
-          id={
-            <Typography variant="body2">
-              {(point as PointTooltipPropsWithLabel).point.data.label}
-            </Typography>
-          }
-          color={point.point.color}
-          enableChip={true}
-        />
-      )}
-      pointSize={10}
       colors={[selectedColor]}
       margin={{ top: 20, right: 10, bottom: 20, left: 35.5 }}
       xScale={{ type: 'linear', min: minX }}
@@ -112,6 +92,7 @@ export const Component: FC<MetricLineProps> = ({
       }}
       enableGridX={false}
       enableGridY={false}
+      pointSize={0}
       useMesh={true}
       layers={[
         CustomAxes,
@@ -134,9 +115,6 @@ export const Component: FC<MetricLineProps> = ({
         ),
         'axes',
         'lines',
-        'points',
-        'markers',
-        'mesh',
       ]}
       theme={lineTheme}
     />

--- a/src/ui/lib/components/MetricsSummary/MetricsSummary.component.tsx
+++ b/src/ui/lib/components/MetricsSummary/MetricsSummary.component.tsx
@@ -102,7 +102,7 @@ export const Component = () => {
   return (
     <>
       <BlockHeader label="Metrics Summary" />
-      <MetricsSummaryContainer sx={{ overflow: 'visible' }} container>
+      <MetricsSummaryContainer container>
         <HeaderLeftCell item xs={9}>
           <Box display="flex" flexDirection="row" justifyContent="space-between">
             <Typography variant="h6" color="surface.onSurface" mb={2}>

--- a/src/ui/lib/store/benchmarksWindowData.ts
+++ b/src/ui/lib/store/benchmarksWindowData.ts
@@ -1,6 +1,5 @@
 export const benchmarksScript = `window.benchmarks = [
   {
-    strategyDisplayStr: "synchronous",
     requestsPerSecond: 11.411616848282272,
     tpot: {
       mean: 8.758024845683707,
@@ -172,7 +171,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@36.28",
     requestsPerSecond: 36.289181300710815,
     tpot: {
       mean: 588.0161376137819,
@@ -344,7 +342,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@20.75",
     requestsPerSecond: 20.752070927855794,
     tpot: {
       mean: 116.28360712595156,
@@ -516,7 +513,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@26.81",
     requestsPerSecond: 26.81917480361788,
     tpot: {
       mean: 299.7306064613554,
@@ -688,7 +684,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@26.82",
     requestsPerSecond: 26.823988819498975,
     tpot: {
       mean: 683.8011571339198,
@@ -860,7 +855,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@24.50",
     requestsPerSecond: 24.50047903792646,
     tpot: {
       mean: 742.9258901891964,
@@ -1032,7 +1026,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@25.61",
     requestsPerSecond: 25.617829792196602,
     tpot: {
       mean: 663.3098317044122,
@@ -1204,7 +1197,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@37.02",
     requestsPerSecond: 37.02892550982192,
     tpot: {
       mean: 606.4144710877113,
@@ -1376,7 +1368,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "constant@37.29",
     requestsPerSecond: 37.29183354201869,
     tpot: {
       mean: 603.3237551205925,
@@ -1548,7 +1539,6 @@ export const benchmarksScript = `window.benchmarks = [
     },
   },
   {
-    strategyDisplayStr: "throughput",
     requestsPerSecond: 37.45318312972309,
     tpot: {
       mean: 600.7204526769262,

--- a/src/ui/lib/store/slices/benchmarks/benchmarks.interfaces.ts
+++ b/src/ui/lib/store/slices/benchmarks/benchmarks.interfaces.ts
@@ -27,7 +27,6 @@ export interface BenchmarkMetrics {
 
 export interface Benchmark extends BenchmarkMetrics {
   requestsPerSecond: number;
-  strategyDisplayStr: string;
 }
 
 export type Benchmarks = Benchmark[];

--- a/tests/unit/presentation/test_data_models.py
+++ b/tests/unit/presentation/test_data_models.py
@@ -1,7 +1,6 @@
 import pytest
 
-from guidellm.presentation.data_models import BenchmarkDatum, Bucket
-from tests.unit.mock_benchmark import mock_generative_benchmark
+from guidellm.presentation.data_models import Bucket
 
 
 @pytest.mark.smoke
@@ -19,10 +18,3 @@ def test_bucket_from_data():
     assert buckets[1].value == 8.0
     assert buckets[1].count == 5
     assert bucket_width == 1
-
-
-@pytest.mark.smoke
-def test_from_benchmark_includes_strategy_display_str():
-    mock_bm = mock_generative_benchmark()
-    bm = BenchmarkDatum.from_benchmark(mock_bm)
-    assert bm.strategy_display_str == "synchronous"


### PR DESCRIPTION
Reverts vllm-project/guidellm#392

That PR was rebased without using the new data types in the refactor branch. Due to it breaking things, it makes most sense to revert it and later submit a new one for the feature.