### PR TITLE
Support dashed arguments for benchmark args

### DIFF
--- a/src/guidellm/benchmark/schemas.py
+++ b/src/guidellm/benchmark/schemas.py
@@ -1887,7 +1887,12 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
     data_request_formatter: DatasetPreprocessor | dict[str, str] | str = Field(
         default="chat_completions",
         description="Request formatting preprocessor or template name",
-        validation_alias=AliasChoices("request_type", "request-type"),
+        validation_alias=AliasChoices(
+            "data_request_formatter",
+            "data-request-formatter",
+            "request_type",
+            "request-type",
+        ),
     )
     data_collator: Callable | Literal["generative"] | None = Field(
         default="generative", description="Data collator for batch processing"


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
For all arguments in `BenchmarkGenerativeTextArgs` support dashed versions of the name during validation to match the CLI. Additionally alias the argument `data_request_formatter` to `request_type`.


## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
Alias are configured so that if both options are specified, the original name takes precedence. E.g. the order of precedence is `max_seconds > max-seconds`.

~~For `data_request_formatter` the request type alias takes precedence. E.g. `request_type > request-type > data_request_formatter`.~~ Changed this because it caused precedence issues with CLI arg. Order is now `data_request_formatter > data-request-formatter > request_type > request-type`.

## Test Plan

The following scenario file can be used to test. Modify which fields are uncommented to test precedence. 

```yaml
target: <hostname>
#request_type: text_completions
#request-type: text_completions
data_request_formatter: text_completions
profile: concurrent
rate: 2
max_seconds: 30
data:
  prompt_tokens: 256
  output_tokens: 128
```

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
