### PR TITLE
Unmask StopIteration in DataLoader

### DIFF
--- a/src/guidellm/data/loaders.py
+++ b/src/guidellm/data/loaders.py
@@ -119,6 +119,8 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
                         # This should be fixed at some point.
                         row = preprocessor(row)  # type: ignore[assignment]
                     yield row  # type: ignore[misc]
+                except StopIteration:
+                    raise  # Stop iteration when any dataset is exhausted
                 except Exception as err:  # noqa: BLE001 # Exception logged
                     logger.error(f"Skipping data row due to error: {err}")
                     gen_count -= 1


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
Fixes bug where dataloader will not recognize the end of a dataset due to the StopIteration Exception being caught and masked.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
