### PR TITLE
Fix container version mismatch by moving build type ARG after FROM

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,15 +1,15 @@
 # TODO: Update to official python-3.13-minimal image when available
 ARG BASE_IMAGE=quay.io/fedora/python-313-minimal:latest
 
+# Use a multi-stage build to create a lightweight production image
+FROM $BASE_IMAGE as builder
+
 # release: take the last version and add a post if build iteration
 # candidate: increment to next minor, add 'rc' with build iteration
 # nightly: increment to next minor, add 'a' with build iteration
 # alpha: increment to next minor, add 'a' with build iteration
 # dev: increment to next minor, add 'dev' with build iteration
 ARG GUIDELLM_BUILD_TYPE=dev
-
-# Use a multi-stage build to create a lightweight production image
-FROM $BASE_IMAGE as builder
 
 # Switch to root for installing packages
 USER root


### PR DESCRIPTION
## Summary

From the log https://github.com/vllm-project/guidellm/actions/runs/18408284407/job/52453702204#step:5:468 , it can be seen that `GUIDELLM_BUILD_TYPE=$GUIDELLM_BUILD_TYPE` in the container file was not correctly assigned. The reason is that the `ARG` instructions defined before `FROM` are global but not available in the build stage context, which can lead to improper version tagging during the build process. This caused the container to use an incorrect version string. Ref to https://docs.docker.com/reference/dockerfile#understand-how-arg-and-from-interact

## Details

Moved the `ARG GUIDELLM_BUILD_TYPE=dev` instruction and its explanatory comments after the `FROM $BASE_IMAGE as builder` statement. This ensures the build type argument is properly scoped to the build stage.


## Test Plan

- In this branch, create a tag such as v0.3.2 and build using `buildah build --build-arg GUIDELLM_BUILD_TYPE=release`, then check if the logs return the correct version.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #453

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
