### PR TITLE
Allow unlimited connections per-worker

### DIFF
--- a/src/guidellm/backends/openai.py
+++ b/src/guidellm/backends/openai.py
@@ -134,6 +134,12 @@ class OpenAIHTTPBackend(Backend):
             timeout=self.timeout,
             follow_redirects=self.follow_redirects,
             verify=self.verify,
+            # Allow unlimited connections
+            limits=httpx.Limits(
+                max_connections=None,
+                max_keepalive_connections=None,
+                keepalive_expiry=5.0,  # default
+            ),
         )
         self._in_process = True
 


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
By default each httpx client supports a maximum of 100 connections ([ref](https://www.python-httpx.org/advanced/resource-limits/)). We want this uncapped as connection count is maintained by a semaphore.

## Test Plan

<!--
List the steps needed to test this PR.
-->
- See #487

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #487 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
