### PR TITLE
Make image_url/video_url send dictionaries

### DIFF
--- a/src/guidellm/data/preprocessors/formatters.py
+++ b/src/guidellm/data/preprocessors/formatters.py
@@ -234,7 +234,10 @@ class GenerativeChatCompletionsRequestFormatter(RequestFormatter):
                 {
                     "role": "user",
                     "content": [
-                        {"type": "image_url", "image_url": image_dict.get("image")}
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_dict.get("image")},
+                        }
                     ],
                 }
             )
@@ -261,7 +264,10 @@ class GenerativeChatCompletionsRequestFormatter(RequestFormatter):
                 {
                     "role": "user",
                     "content": [
-                        {"type": "video_url", "video_url": video_dict.get("video")}
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": video_dict.get("video")},
+                        }
                     ],
                 }
             )


### PR DESCRIPTION


## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
This PR changes how GuideLLM sends image/video urls to the backend using the chat_completions endpoint. The current behaviour doesn't seem to follow spec, which was giving me trouble benchmarking a multimodal dataset.

Both vLLM and the OpenAI spec expect message content of type `image_url` to be a dictionary like `{"url": <url>}`, though the previous behaviour sent the url as a plain string. `video_url` is vLLM-only as far as I know though it follows the same schema.

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ] Updated the chat_completions request to match the spec
   * Old behaviour:
      ```
          {
              "role": "user",
              "content": [
                  {
                      "type": "image_url",
                      "image_url": <image_url>
                  }
              ]
          }
      ```
    * New behaviour:
         ```
                {
                    "role": "user",
                    "content": [
                        {
                            "type": "image_url",
                            "image_url": {"url": <image_url>}
                        }
                    ]
                }
         ```

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
