### PR TITLE
Use total requests for throughput calculation

### DIFF
--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -468,30 +468,35 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
             )
             columns.add_stats(
                 benchmark.metrics.requests_per_second,
+                status="total",
                 group="Requests",
                 name="Per Sec",
                 types=("median", "mean"),
             )
             columns.add_stats(
                 benchmark.metrics.request_concurrency,
+                status="total",
                 group="Requests",
                 name="Concurrency",
                 types=("median", "mean"),
             )
             columns.add_stats(
                 benchmark.metrics.prompt_tokens_per_second,
+                status="total",
                 group="Input Tokens",
                 name="Per Sec",
                 types=("median", "mean"),
             )
             columns.add_stats(
                 benchmark.metrics.output_tokens_per_second,
+                status="total",
                 group="Output Tokens",
                 name="Per Sec",
                 types=("median", "mean"),
             )
             columns.add_stats(
                 benchmark.metrics.tokens_per_second,
+                status="total",
                 group="Total Tokens",
                 name="Per Sec",
                 types=("median", "mean"),
@@ -499,7 +504,9 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
 
         headers, values = columns.get_table_data()
         self.console.print("\n")
-        self.console.print_table(headers, values, title="Server Throughput Statistics")
+        self.console.print_table(
+            headers, values, title="Server Throughput Statistics (All Requests)"
+        )
 
     def _print_modality_table(
         self,


### PR DESCRIPTION
## Summary

Switches "Server Throughput Statistics" table in console output to use total request pool rather then just successful. See #529 for reasoning.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #529 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
