### PR TITLE
Fixup pylock after dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,33 @@
+---
+name: Dependabot Pull Request
+on: pull_request
+jobs:
+  dependabot:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+    - name: Fetch Dependabot metadata
+      id: dependabot-metadata
+      uses: dependabot/fetch-metadata@v2
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+    - name: Update pylock
+      run: |
+        UV_FROZEN=1 ./scripts/generate_pylock.sh
+    - name: Commit and Push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add pylock.toml
+          # Only commit if there are actually changes
+          if ! git diff --cached --quiet; then
+            git commit -m "auto-update pylock from dependabot"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
Dependabot seems to have recently added support for updating `uv` packages with CVEs but it does not update the pylock along with it. This PR adds a CI job to automatically commit a pylock update to dependabot PRs.

## Test Plan

Can only be tested once merged

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
