### PR TITLE
fix(cli): validate --output-path against --output-dir

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -422,7 +422,7 @@ def run(**kwargs):  # noqa: C901
 
     # Handle output path remapping
     if (output_path := kwargs.pop("output_path", None)) is not None:
-        if kwargs.get("outputs_dir", None) is not None:
+        if kwargs.get("output_dir", None) is not None:
             raise click.BadParameter("Cannot use --output-path with --output-dir.")
         path = Path(output_path)
         if path.is_dir():


### PR DESCRIPTION
## Summary

Fix CLI validation so `--output-path` correctly conflicts with `--output-dir`, not the mistyped `outputs_dir`.

## Details
- [x] Update the mutual exclusion check between `--output-path` and `--output-dir`

## Test Plan
- Not run (small validation change)

## Related Issues
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests
