### PR TITLE
Containerfile: ensure that HOME can be used by any user ID

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -75,7 +75,7 @@ ENV HOME="/home/guidellm" \
 # Create the user home dir
 WORKDIR $HOME
 
-# Ensure that the user home dir can be used by any user 
+# Ensure that the user home dir can be used by any user
 # (OpenShift Pods can't use the cache otherwise)
 RUN chgrp -R 0 "$HOME" && chmod -R g=u "$HOME"
 


### PR DESCRIPTION
OpenShift Pods can't use the cache otherwise

Resolves: 600

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
