### PR TITLE
Fix JSON serialization for binary request payloads via base64 bytes config

### DIFF
--- a/src/guidellm/schemas/base.py
+++ b/src/guidellm/schemas/base.py
@@ -56,6 +56,8 @@ class ReloadableBaseModel(BaseModel):
         use_enum_values=True,
         from_attributes=True,
         arbitrary_types_allowed=True,
+        ser_json_bytes="base64",
+        val_json_bytes="base64",
     )
 
     @classmethod
@@ -169,6 +171,8 @@ class StandardBaseModel(BaseModel):
         extra="ignore",
         use_enum_values=True,
         from_attributes=True,
+        ser_json_bytes="base64",
+        val_json_bytes="base64",
     )
 
     @classmethod
@@ -198,6 +202,8 @@ class StandardBaseDict(StandardBaseModel):
         use_enum_values=True,
         from_attributes=True,
         arbitrary_types_allowed=True,
+        ser_json_bytes="base64",
+        val_json_bytes="base64",
     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes a serialization failure when request arguments include binary data (for example, audio bytes in multipart file payloads).  
It configures Pydantic JSON byte handling to use base64 encoding so `model_dump_json()` no longer raises `PydanticSerializationError` on non-UTF8 bytes.

## Details

- [x] Set global Pydantic JSON bytes behavior in shared schema base configs:
  - `ser_json_bytes="base64"`
  - `val_json_bytes="base64"`
- [x] Applied the setting to:
  - `ReloadableBaseModel`
  - `StandardBaseModel`
  - `StandardBaseDict`
- [x] Verified the minimal reproduction now succeeds:
  - `GenerationRequestArguments(... files={"file": ("a.wav", b"...", "audio/wav")}).model_dump_json()`
- [x] Verified AudioRequestHandler streaming compile path no longer crashes with binary audio content

## Test Plan

- Run MRE:
  - `uv run --no-sync python - <<'PY'`
  - create `GenerationRequestArguments` with non-UTF8 bytes in `files`
  - call `model_dump_json()`
  - confirm output succeeds and bytes are encoded as base64
- Run handler-level repro:
  - instantiate `AudioRequestHandler`
  - format request with binary `audio_column`
  - simulate streaming line
  - call `compile_streaming(...)`
  - confirm no serialization exception

## Related Issues

- Resolves #611

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)