### PR TITLE
Drop median from throughput metrics in console

### DIFF
--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -467,18 +467,18 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
                 type_="text",
             )
             columns.add_stats(
+                benchmark.metrics.request_concurrency,
+                status="total",
+                group="Requests",
+                name="Concurrency",
+                types=("median", "mean"),
+            )
+            columns.add_stats(
                 benchmark.metrics.requests_per_second,
                 status="total",
                 group="Requests",
                 name="Per Sec",
                 types=("mean",),
-            )
-            columns.add_stats(
-                benchmark.metrics.request_concurrency,
-                status="total",
-                group="Requests",
-                name="Concurrency",
-                types=("mean", "median"),
             )
             columns.add_stats(
                 benchmark.metrics.prompt_tokens_per_second,


### PR DESCRIPTION
## Summary

Only show mean for request/token based concurrences. See #602 for reasoning.

## Details

Result of change:

```
ℹ Server Throughput Statistics (All Requests)
|============|=======|======|=========|==============|===============|==============|
| Benchmark  | Requests             ||| Input Tokens | Output Tokens | Total Tokens |
| Strategy   | Concurrency || Per Sec | Per Sec      | Per Sec       | Per Sec      |
|            | Mdn   | Mean | Mean                                               ||||
|------------|-------|------|---------|--------------|---------------|--------------|
| concurrent | 25.0  | 25.0 | 2.3     | 2662.3       | 2319.4        | 4775.9       |
|============|=======|======|=========|==============|===============|==============|



✔ Benchmarking complete, generated 1 benchmark(s)
…   json    : /root/guidellm/benchmarks.json
…   csv     : /root/guidellm/benchmarks.csv
…   html    : /root/guidellm/benchmarks.html
```

## Related Issues

- Related to #602

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
