### PR TITLE
Add detail in benchmark profile documentation

### DIFF
--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -161,7 +161,6 @@ For synthetic data, parameters for random data generation are passed as key=valu
 
 - `prompt_tokens`: Average number of tokens for prompts
 - `output_tokens`: Average number of tokens for outputs
-- `samples`: Number of samples to generate (default: 1000)
 
 For example, to generate 1000 samples with a prompt length of 100 tokens and an output length of 50 tokens:
 


### PR DESCRIPTION
## Summary

Attempt to clarify the interactions of `--rate` and the count and time-based constraints with the various benchmarking profiles; especially sweep, which presents effects that aren't obvious at first glance.

## Details

The simple list of profiles is broken up into sub-sections with more detail on behavior and interactions to, hopefully, aid in understanding.

## Test Plan

N/A

## Related Issues

This is a first attempt to mitigate the implications of #588 with a clear warning that the global constraints are implemented separately for each strategy, and that sweep especially includes multiple strategies. We expect that future work will allow specifying separate constraints for each strategy.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
