### PR TITLE
docs: add documentation for passing sampling parameters via --backend-kwargs

### DIFF
--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -82,7 +82,8 @@ guidellm benchmark \
 
 The API key is used to set the `Authorization: Bearer {api_key}` header in HTTP requests to the backend server.
 
-> [!IMPORTANT] For security, avoid hardcoding API keys in scripts. Consider using environment variables or secure credential management tools when passing API keys via `--backend-kwargs`.
+> [!IMPORTANT]\
+> For security, avoid hardcoding API keys in scripts. Consider using environment variables or secure credential management tools when passing API keys via `--backend-kwargs`.
 
 ## Passing Sampling Parameters
 


### PR DESCRIPTION
## Summary

Add a new "Passing Sampling Parameters" section to `docs/guides/backends.md` that documents how to pass sampling parameters (e.g., `temperature`, `top_p`, `top_k`) to the backend server via the `--backend-kwargs` CLI option.

This is a common source of confusion for users, as the correct syntax requires nesting sampling parameters under `extras.body` (i.e., `--backend-kwargs '{"extras": {"body": {"temperature": 0.6}}}'`) rather than passing them directly as top-level backend arguments.

## Details

 Added a new `## Passing Sampling Parameters` section to `docs/guides/backends.md`
- Documented the `extras.body` field structure for passing sampling parameters
- Included a practical example showing `temperature`, `top_p`, and `top_k` usage
- Added a "How It Works" subsection explaining the `GenerationRequestArguments` sub-fields (`body`, `headers`, `params`)
- Added a combined example showing sampling parameters alongside other backend options like `api_key`
- Noted that `--backend-args` is a legacy alias for `--backend-kwargs`
## Test Plan

Documentation-only change; no functional code changes
- Verify the markdown renders correctly on GitHub
## Related Issues

- Related to #69 (How to pass additional sampling parameters to the vllm server?)