### PR TITLE
Move html template source location to raw github

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -75,7 +75,7 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
 
           # Set asset prefix and base path with PR number
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/pr/${PR_NUMBER}
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/pr/${PR_NUMBER}
           USE_MOCK_DATA=true
           BASE_PATH=/ui/pr/${PR_NUMBER}
           GIT_SHA=${{ github.sha }}
@@ -102,7 +102,7 @@ jobs:
         if: steps.check-changes.outputs.should_build == 'true'
         id: deploy
         run: |
-          DEPLOY_URL=https://blog.vllm.ai/guidellm/ui/pr/${{ steps.build.outputs.pr_number }}
+          DEPLOY_URL=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/pr/${{ steps.build.outputs.pr_number }}
           echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
 
       - name: Find PR comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           export $(grep -v '^#' .env.development | xargs)
 
           # Set asset prefix and base path with PR number
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/dev
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev
           BASE_PATH=/ui/dev
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,7 +108,7 @@ jobs:
           export $(grep -v '^#' .env.staging | xargs)
 
           # Set asset prefix and base path with git tag
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/nightly
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/nightly
           BASE_PATH=/ui/nightly
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -97,7 +97,7 @@ jobs:
           export $(grep -v '^#' .env.staging | xargs)
 
           # Set asset prefix and base path with git tag
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/${{ env.TAG }}
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/${{ env.TAG }}
           BASE_PATH=/ui/${{ env.TAG }}
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}
@@ -151,7 +151,7 @@ jobs:
           export $(grep -v '^#' .env.staging | xargs)
 
           # Set asset prefix and base path with git tag
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/release/latest
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/latest
           BASE_PATH=/ui/release/latest
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           export $(grep -v '^#' .env.production | xargs)
 
           # Set asset prefix and base path with git tag
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/${{ env.TAG }}
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/${{ env.TAG }}
           BASE_PATH=/ui/${{ env.TAG }}
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}
@@ -151,7 +151,7 @@ jobs:
           export $(grep -v '^#' .env.production | xargs)
 
           # Set asset prefix and base path with git tag
-          ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/latest
+          ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/latest
           BASE_PATH=/ui/latest
           GIT_SHA=${{ github.sha }}
           export ASSET_PREFIX=${ASSET_PREFIX}

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -31,9 +31,9 @@ class Environment(str, Enum):
 
 
 ENV_REPORT_MAPPING = {
-    Environment.PROD: "https://blog.vllm.ai/guidellm/ui/v0.5.0/index.html",
-    Environment.STAGING: "https://blog.vllm.ai/guidellm/ui/release/v0.4.0/index.html",
-    Environment.DEV: "https://blog.vllm.ai/guidellm/ui/dev/index.html",
+    Environment.PROD: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/v0.6.0/index.html",
+    Environment.STAGING: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/v0.6.0/index.html",
+    Environment.DEV: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev/index.html",
     Environment.LOCAL: "http://localhost:3000/index.html",
 }
 

--- a/src/ui/.env.development
+++ b/src/ui/.env.development
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/dev
+ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev
 BASE_PATH=/ui/dev
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/src/ui/.env.production
+++ b/src/ui/.env.production
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/latest
+ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/latest
 BASE_PATH=/ui/latest
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/src/ui/.env.staging
+++ b/src/ui/.env.staging
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://blog.vllm.ai/guidellm/ui/release/latest
+ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/latest
 BASE_PATH=/ui/release/latest
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,7 +11,9 @@ from guidellm.settings import (
     settings,
 )
 
-BASE_URL = "https://blog.vllm.ai/guidellm/ui/"
+BASE_URL = (
+    "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/"
+)
 
 
 @pytest.mark.smoke
@@ -47,7 +49,7 @@ def test_report_generation_default_source():
     settings = Settings(env=Environment.DEV)
     assert (
         settings.report_generation.source
-        == "https://blog.vllm.ai/guidellm/ui/dev/index.html"
+        == "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev/index.html"
     )
 
     settings = Settings(env=Environment.STAGING)


### PR DESCRIPTION
## Summary

Point UI to HTML template on `raw.githubusercontent.com` rather than `blog.vllm.ai`.

## Test Plan

Will have to be tested after CI fires.

## Related Issues

- Resolves #627 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
