### PR TITLE
docs: Fixing a broken link of docs/guides/outputs.md.

### DIFF
--- a/docs/guides/outputs.md
+++ b/docs/guides/outputs.md
@@ -161,4 +161,4 @@ for benchmark in benchmarks:
     print(benchmark.id_)
 ```
 
-For more details on the `GenerativeBenchmarksReport` class and its methods, refer to the [source code](https://github.com/vllm-project/guidellm/blob/main/src/guidellm/benchmark/schemas/generative/reports.py).
+For more details on the `GenerativeBenchmarksReport` class and its methods, refer to the [source code](https://github.com/vllm-project/guidellm/blob/main/src/guidellm/benchmark/schemas/generative/report.py).


### PR DESCRIPTION
## Summary

Fixing a broken link of docs/guides/outputs.md.

## Details

Update a broken link from https://github.com/vllm-project/guidellm/blob/main/src/guidellm/benchmark/schemas/generative/reports.py to https://github.com/vllm-project/guidellm/blob/main/src/guidellm/benchmark/schemas/generative/report.py

## Test Plan

document update only.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

