### PR TITLE
fix(synthetic): align _SyntheticTextExamplesIterable with HuggingFace…

### DIFF
--- a/src/guidellm/data/deserializers/synthetic.py
+++ b/src/guidellm/data/deserializers/synthetic.py
@@ -105,6 +105,11 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
     def num_shards(self) -> int:
         return 1
 
+    @property
+    def n_shards(self) -> int:
+        """Alias for num_shards; required by HuggingFace datasets IterableDataset API."""
+        return self.num_shards
+
     def shuffle_data_sources(
         self,
         generator: np.random.Generator,  # noqa: ARG002
@@ -114,11 +119,10 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
 
     def shard_data_sources(
         self,
-        num_shards: int,  # noqa: ARG002
-        index: int,  # noqa: ARG002
-        contiguous: bool = True,  # noqa: ARG002
+        worker_id: int,  # noqa: ARG002
+        num_workers: int,  # noqa: ARG002
     ) -> _SyntheticTextExamplesIterable:
-        """Return self since synthetic data generation is infinite and stateless."""
+        """HuggingFace API: return self since synthetic data is infinite and stateless."""
         return self
 
     def load_state_dict(self, state_dict: dict) -> None:


### PR DESCRIPTION
… datasets API

- Add n_shards property (alias of num_shards). HuggingFace IterableDataset expects n_shards; without it, loading synthetic data raises NotImplementedError.
- Change shard_data_sources(worker_id, num_workers) to match the base _BaseExamplesIterable API; the previous signature (num_shards, index, contiguous) caused 'unexpected keyword argument worker_id' when using multiple DataLoader workers. Fixes synthetic data loader when used with datasets.IterableDataset.

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
