### PR TITLE
Add turn and conversation trackers to the request

### DIFF
--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -508,12 +508,16 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                 requests_chain: Iterable[RequestT],
             ) -> Generator[RequestDataT[RequestT], None, None]:
                 nonlocal count, stop_queueing
-                for request in requests_chain:
+                # NOTE: This allows users to correlate requests in post-processing
+                conv_id = str(uuid.uuid4())
+                for i, request in enumerate(requests_chain):
                     count += 1
 
                     request_id = self._find_request_id(request)
                     request_info: RequestInfo = RequestInfo(
                         request_id=request_id,
+                        conversation_id=conv_id,
+                        turn_index=i,
                         status="queued",
                         scheduler_process_id=0,
                         scheduler_start_time=self.start_time,

--- a/src/guidellm/schemas/info.py
+++ b/src/guidellm/schemas/info.py
@@ -125,6 +125,16 @@ class RequestInfo(StandardBaseModel):
         description="Unique identifier for the request",
         default_factory=lambda: str(uuid.uuid4()),
     )
+    conversation_id: str | None = Field(
+        default=None,
+        description=(
+            "Identifier for the conversation this request is part of, if applicable."
+        ),
+    )
+    turn_index: int = Field(
+        default=0,
+        description="Index of the request within the conversation, if applicable.",
+    )
     status: Literal[
         "queued",
         "pending",


### PR DESCRIPTION
## Summary

Adds a conversation id and turn index to requests. This allows users to post-process different views of turn-by-turn metrics.

## Test Plan

Run a benchmark and verify the fields are present:

```sh
$ jq '.benchmarks[0].requests.successful[0].info' benchmarks.json
{
  ...
  "conversation_id": "80d8317d-a900-4464-8c52-3f3bb695cf1e",
  "turn_index": 0,
  ...
}
```

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
