### PR TITLE
Require datasets 4.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ keywords = [
 dependencies = [
     "click~=8.3.0",
     "culsans~=0.10.0",
-    "datasets",
+    "datasets>=4.1.0",
     "eval_type_backport",
     "faker",
     "ftfy>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -926,7 +926,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "click", specifier = "~=8.3.0" },
     { name = "culsans", specifier = "~=0.10.0" },
-    { name = "datasets" },
+    { name = "datasets", specifier = ">=4.1.0" },
     { name = "datasets", extras = ["audio"], marker = "extra == 'audio'", specifier = ">=4.1.0" },
     { name = "datasets", extras = ["vision"], marker = "extra == 'vision'" },
     { name = "eval-type-backport" },


### PR DESCRIPTION
## Summary

Update Huggingface datasets dependency: unversioned dependency can break with an old previously installed datasets package.

## Details

We previously had an unversioned dependency on datasets, and a recent report shows that GuideLLM is not compatible with versions of datasets prior to 3.1.0.

Since the "audio" extra already depends on datasets 4.1.0 we know that works and it seems a reasonable target.

## Test Plan



## Related Issues


---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
