### PR TITLE
Mark requeue test as xfail due to uvloop bug

### DIFF
--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -866,6 +866,7 @@ class TestWorkerProcessMultiturn:
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="https://github.com/MagicStack/uvloop/issues/739")
     @async_timeout(15)
     async def test_requeue_with_positive_delay(self, worker_instance):
         """Test requeueing with positive delay sleeps then appends to turns_queue.


### PR DESCRIPTION
## Summary

Mark the `TestWorkerProcessMultiturn.test_requeue_with_positive_delay` as XFAIL due to a bug in uvloop.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Related to https://github.com/MagicStack/uvloop/issues/739

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
