### PR TITLE
Add a health check for the worker processes

### DIFF
--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -295,12 +295,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             if dead:
                 message = "; ".join(dead)
                 if killed_by_signal:
-                    message += (
-                        ". Check system logs for details."
-                        " Consider an alternative multiprocessing start method"
-                        " (spawn, fork, forkserver) via the"
-                        " GUIDELLM__MP_CONTEXT_TYPE environment variable"
-                    )
+                    message += ". Check system logs for details"
                 self._worker_error_details = message
                 if self.error_event is not None:
                     self.error_event.set()

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -10,6 +10,7 @@ across distributed workers processing concurrent requests.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import math
 import threading
 import time
@@ -129,6 +130,10 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         self.constraint_reached_event: Event | None = None
         self.shutdown_event: Event | None = None
         self.error_event: Event | None = None
+
+        # Background health monitor, created in create_processes
+        self._health_monitor_task: asyncio.Task | None = None
+        self._worker_error_details: str | None = None
 
         # Scheduler and messaging state, created in start
         self.state: WorkerGroupState[RequestT, ResponseT] | None = None
@@ -252,6 +257,8 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             proc.start()
             self.processes.append(proc)
 
+        self._health_monitor_task = asyncio.create_task(self._process_health_monitor())
+
         wait_key = await wait_for_sync_objects(
             {
                 "startup_barrier": self.startup_barrier,
@@ -262,9 +269,42 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         )
 
         if wait_key == "error_event":
-            raise RuntimeError(
-                "Worker process group startup failed: error_event is set"
-            )
+            detail = self._worker_error_details or "error_event is set"
+            raise RuntimeError(f"Worker process group startup failed: {detail}")
+
+    async def _process_health_monitor(self):
+        """Detect worker processes killed by OS signals (e.g. SIGSEGV, OOM)
+        that bypass Python exception handling and never set error_event."""
+        while self.processes:
+            await asyncio.sleep(settings.mp_poll_interval)
+            dead: list[str] = []
+            killed_by_signal = False
+            for proc in self.processes:
+                if not proc.is_alive() and proc.exitcode is not None:
+                    if proc.exitcode < 0:
+                        killed_by_signal = True
+                        exit_info = f"signal {-proc.exitcode}"
+                    else:
+                        exit_info = f"exit code {proc.exitcode}"
+                    detail = (
+                        f"Worker process {proc.pid} died unexpectedly ({exit_info})"
+                    )
+                    logger.error(detail)
+                    dead.append(detail)
+
+            if dead:
+                message = "; ".join(dead)
+                if killed_by_signal:
+                    message += (
+                        ". Check system logs for details."
+                        " Consider an alternative multiprocessing start method"
+                        " (spawn, fork, forkserver) via the"
+                        " GUIDELLM__MP_CONTEXT_TYPE environment variable"
+                    )
+                self._worker_error_details = message
+                if self.error_event is not None:
+                    self.error_event.set()
+                return
 
     async def start(self, start_time: float):
         """
@@ -314,10 +354,11 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         if (wait_time := start_time - time.time()) > 0:
             await asyncio.sleep(wait_time)
         if self.error_event.is_set():
-            raise RuntimeError(
-                "error_event is set in WorkerProcessGroup, "
-                "indicating an error occurred in one of the worker processes."
+            detail = (
+                self._worker_error_details
+                or "an error occurred in one of the worker processes"
             )
+            raise RuntimeError(f"error_event is set in WorkerProcessGroup: {detail}")
 
     async def request_updates(
         self,
@@ -343,9 +384,12 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         while True:
             if self.error_event.is_set():  # type: ignore[union-attr]
                 logger.error("Error event set in WorkerProcessGroup")
+                detail = (
+                    self._worker_error_details
+                    or "an error occurred in one of the worker processes"
+                )
                 raise RuntimeError(
-                    "error_event is set in WorkerProcessGroup, "
-                    "indicating an error occurred in one of the worker processes."
+                    f"error_event is set in WorkerProcessGroup: {detail}"
                 )
 
             try:
@@ -373,6 +417,13 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         :return: List of exceptions encountered during shutdown; empty if no errors
         """
         exceptions: list[Exception] = []
+
+        if self._health_monitor_task is not None:
+            self._health_monitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._health_monitor_task
+            self._health_monitor_task = None
+
         if self.shutdown_event is not None:
             self.shutdown_event.set()
 
@@ -390,10 +441,15 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             for proc in self.processes:
                 try:
                     await asyncio.to_thread(proc.join, timeout=5.0)
-                    if proc.exitcode is not None and proc.exitcode > 0:
+                    if proc.exitcode is not None and proc.exitcode != 0:
+                        exit_info = (
+                            f"signal {-proc.exitcode}"
+                            if proc.exitcode < 0
+                            else f"exit code {proc.exitcode}"
+                        )
                         exceptions.append(
                             RuntimeError(
-                                f"Worker {proc.pid} exited with code {proc.exitcode}"
+                                f"Worker {proc.pid} exited abnormally ({exit_info})"
                             )
                         )
                 except Exception as err:  # noqa: BLE001


### PR DESCRIPTION
## Summary

Creates an Async IO task that polls for failure of the worker processes.

This is necessary because if this happens presently, it doesn't detect the failure, and continues waiting idefinitely for the process to be ready, causing a hang.

## Details

- Polls the worker processes
- In the event of a failure, it creates a human-readable error message with the exit code or the type of failure.

Here is what it looks like with a segmentation fault, which I've been getting.
```
╭─ Benchmarks ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [--:--:--] ⠏   0% constant@1.00 (pending )                                                                                                                                                                                                                  │
│                                                                                                                                                                                                                                                             │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Generating... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1/1) [ 0:00:28 < -:--:-- ]26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13820 died unexpectedly (signal 11)
26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13821 died unexpectedly (signal 11)
26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13822 died unexpectedly (signal 11)
26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13823 died unexpectedly (signal 11)
26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13824 died unexpectedly (signal 11)
26-04-03 12:41:20|ERROR            |guidellm.scheduler.worker_group:_process_health_monitor:292 - Worker process 13825 died unexpectedly (signal 11)
Traceback (most recent call last):
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/bin/guidellm", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/.venv3.12/lib/python3.12/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/__main__.py", line 476, in run
    asyncio.run(
  File "/opt/homebrew/Cellar/python@3.12/3.12.10_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.10_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/benchmark/entrypoints.py", line 554, in benchmark_generative_text
    async for benchmark in benchmarker.run(
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/benchmark/benchmarker.py", line 133, in run
    async for (
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/scheduler/scheduler.py", line 143, in run
    raise err
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/scheduler/scheduler.py", line 126, in run
    await worker_group.create_processes()
  File "/Users/joconnel/Documents/projects/ai/guidellm/src/guidellm/scheduler/worker_group.py", line 273, in create_processes
    raise RuntimeError(f"Worker process group startup failed: {detail}")
RuntimeError: Worker process group startup failed: Worker process 13820 died unexpectedly (signal 11); Worker process 13821 died unexpectedly (signal 11); Worker process 13822 died unexpectedly (signal 11); Worker process 13823 died unexpectedly (signal
11); Worker process 13824 died unexpectedly (signal 11); Worker process 13825 died unexpectedly (signal 11); Worker process 13826 died unexpectedly (signal 11); Worker process 13827 died unexpectedly (signal 11); Worker process 13828 died unexpectedly
(signal 11); Worker process 13829 died unexpectedly (signal 11). Check system logs for details. Consider an alternative multiprocessing start method (spawn, fork, forkserver) via the GUIDELLM__MP_CONTEXT_TYPE environment variable
```
In this situation, all of them had segmentation faults at the same time for some reason. The system reported a segmentation fault to me.

## Test Plan

- You can probably kill a worker process to see it work.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
