### PR TITLE
Process tool call requests for chat completions API

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -406,7 +406,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
     def __init__(self):
         super().__init__()
-        self.streaming_tool_calls: dict[int, dict] = {}
+        self.streaming_tool_call_indices: set[int] = set()
 
     def _format_prompts(
         self, column_data: list[dict[str, Any]], column_type: str
@@ -554,10 +554,11 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choices, usage = self.extract_choices_and_usage(response)
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
-        # content is null for tool-call-only responses (text=None means text
-        # metrics are excluded); empty string for rare edge cases where the
-        # model returns no text (text="" means text metrics are 0).
+        # Per spec, content is null when the model produces tool calls instead
+        # of text. text=None excludes text metrics; text="" means text metrics
+        # are 0 for the rare empty-content edge case.
         text = message.get("content")
+        # Per spec, tool_calls is present when content is null.
         tool_calls = message.get("tool_calls") if text is None else None
         if text is None and not tool_calls:
             text = ""
@@ -601,26 +602,11 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.streaming_texts.append(content)
             updated = True
 
-        # Tool call streaming sends incremental chunks via delta.tool_calls.
-        # Each chunk (tc_delta) carries an "index" identifying which tool call
-        # it belongs to (for parallel tool calls), plus partial fragments of
-        # function.name and function.arguments that must be concatenated across
-        # multiple SSE events to reconstruct the complete call.
+        # tool_calls is absent from text-only deltas; empty default is
+        # spec-correct. Each entry carries a required "index" identifying the
+        # tool call; missing index raises KeyError → errored request.
         for tc_delta in delta.get("tool_calls", []):
-            idx = tc_delta.get("index", 0)
-            if idx not in self.streaming_tool_calls:
-                # First chunk for this tool call: initialize with id and type
-                self.streaming_tool_calls[idx] = {
-                    "id": tc_delta.get("id", ""),
-                    "type": tc_delta.get("type", "function"),
-                    "function": {"name": "", "arguments": ""},
-                }
-            tc = self.streaming_tool_calls[idx]
-            fn_delta = tc_delta.get("function", {})
-            if fn_name := fn_delta.get("name"):
-                tc["function"]["name"] += fn_name
-            if fn_args := fn_delta.get("arguments"):
-                tc["function"]["arguments"] += fn_args
+            self.streaming_tool_call_indices.add(tc_delta["index"])
             updated = True
 
         if usage:
@@ -638,13 +624,13 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
         text = "".join(self.streaming_texts) or None
-        has_tool_calls = text is None and bool(self.streaming_tool_calls)
+        has_tool_calls = text is None and bool(self.streaming_tool_call_indices)
         if text is None and not has_tool_calls:
             text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
         if has_tool_calls:
             output_metrics.tool_call_tokens = output_metrics.text_tokens
-            output_metrics.tool_call_count = len(self.streaming_tool_calls)
+            output_metrics.tool_call_count = len(self.streaming_tool_call_indices)
 
         return GenerationResponse(
             request_id=request.request_id,

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -335,19 +335,29 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         return response.get("choices", []), response.get("usage", {})
 
     def extract_metrics(
-        self, usage: dict[str, int | dict[str, int]] | None, text: str
+        self, usage: dict[str, int | dict[str, int]] | None, text: str | None
     ) -> tuple[UsageMetrics, UsageMetrics]:
         """
         Extract input and output usage metrics from API response usage data.
 
         :param usage: Usage data dictionary from API response
-        :param text: Generated text for calculating word and character counts
+        :param text: Generated text for calculating word and character counts.
+            None means text is not applicable (metrics will be None);
+            empty string means text was applicable but empty (metrics will be 0).
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
+        if text is None:
+            # text not applicable (e.g. tool-call-only) — exclude from aggregation
+            text_words = None
+            text_chars = None
+        else:
+            text_words = len(text.split())
+            text_chars = len(text)
+
         if not usage:
             return UsageMetrics(), UsageMetrics(
-                text_words=len(text.split()) if text else 0,
-                text_characters=len(text) if text else 0,
+                text_words=text_words,
+                text_characters=text_chars,
             )
 
         input_details: dict[str, int] = cast(
@@ -374,8 +384,8 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
                 or usage_metrics.get("completion_tokens")
                 or 0
             ),
-            text_words=len(text.split()) if text else 0,
-            text_characters=len(text) if text else 0,
+            text_words=text_words,
+            text_characters=text_chars,
             image_tokens=output_details.get("image_tokens"),
             video_tokens=output_details.get("video_tokens"),
             audio_tokens=output_details.get("audio_tokens"),
@@ -525,27 +535,6 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         return arguments
 
-    @staticmethod
-    def _tool_calls_to_text(tool_calls: list[dict]) -> str:
-        """Serialize a ``tool_calls`` array to a JSON string."""
-        # orjson.dumps returns bytes; stdlib json.dumps returns str
-        raw = json.dumps(tool_calls)
-        return raw.decode("utf-8") if isinstance(raw, bytes) else raw
-
-    @staticmethod
-    def _add_tool_call_metrics(
-        output_metrics: UsageMetrics, tool_call_count: int
-    ) -> None:
-        """Tag output metrics with tool call info (subset of text metrics).
-
-        Sets ``tool_call_tokens`` equal to ``text_tokens`` (since the server
-        reports all completion tokens together) and records the number of
-        individual tool calls. These fields are additive metadata -- they do
-        not affect ``total_tokens``.
-        """
-        output_metrics.tool_call_tokens = output_metrics.text_tokens
-        output_metrics.tool_call_count = tool_call_count
-
     def compile_non_streaming(
         self,
         request: GenerationRequest,
@@ -556,8 +545,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         Process a complete chat completion response.
 
         Extracts content from the message object within choices, handling the nested
-        structure specific to chat completion endpoints. When the model returns tool
-        calls instead of text content, the tool calls are serialized as JSON text.
+        structure specific to chat completion endpoints.
 
         :param request: Original generation request
         :param response: Complete API response containing choices and usage data
@@ -566,14 +554,17 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choices, usage = self.extract_choices_and_usage(response)
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
-        text = message.get("content") or ""
-        # Tool call responses set content=null and put output in tool_calls
-        tool_calls = message.get("tool_calls") if not text else None
-        if tool_calls:
-            text = self._tool_calls_to_text(tool_calls)
+        # content is null for tool-call-only responses (text=None means text
+        # metrics are excluded); empty string for rare edge cases where the
+        # model returns no text (text="" means text metrics are 0).
+        text = message.get("content")
+        tool_calls = message.get("tool_calls") if text is None else None
+        if text is None and not tool_calls:
+            text = ""
         input_metrics, output_metrics = self.extract_metrics(usage, text)
         if tool_calls:
-            self._add_tool_call_metrics(output_metrics, len(tool_calls))
+            output_metrics.tool_call_tokens = output_metrics.text_tokens
+            output_metrics.tool_call_count = len(tool_calls)
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -643,23 +634,17 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         """
         Compile accumulated streaming chat completion content into a final response.
 
-        When no text content was streamed but tool calls were accumulated, the tool
-        calls are serialized as JSON text.
-
         :param request: Original generation request
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
-        text = "".join(self.streaming_texts)
-        has_tool_calls = not text and bool(self.streaming_tool_calls)
-        if has_tool_calls:
-            tool_calls_list = [
-                self.streaming_tool_calls[idx]
-                for idx in sorted(self.streaming_tool_calls)
-            ]
-            text = self._tool_calls_to_text(tool_calls_list)
+        text = "".join(self.streaming_texts) or None
+        has_tool_calls = text is None and bool(self.streaming_tool_calls)
+        if text is None and not has_tool_calls:
+            text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
         if has_tool_calls:
-            self._add_tool_call_metrics(output_metrics, len(self.streaming_tool_calls))
+            output_metrics.tool_call_tokens = output_metrics.text_tokens
+            output_metrics.tool_call_count = len(self.streaming_tool_calls)
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -756,7 +741,7 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
         return arguments
 
     def extract_metrics(
-        self, usage: dict[str, int | dict[str, int]] | None, text: str
+        self, usage: dict[str, int | dict[str, int]] | None, text: str | None
     ) -> tuple[UsageMetrics, UsageMetrics]:
         """
         Extract input and output usage metrics from audio API response usage data.
@@ -765,13 +750,23 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
         in addition to standard text token counts.
 
         :param usage: Usage data dictionary from audio API response
-        :param text: Generated text for calculating word and character counts
+        :param text: Generated text for calculating word and character counts.
+            None means text is not applicable (metrics will be None);
+            empty string means text was applicable but empty (metrics will be 0).
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
+        if text is None:
+            # text not applicable (e.g. tool-call-only) — exclude from aggregation
+            text_words = None
+            text_chars = None
+        else:
+            text_words = len(text.split())
+            text_chars = len(text)
+
         if not usage:
             return UsageMetrics(), UsageMetrics(
-                text_words=len(text.split()) if text else 0,
-                text_characters=len(text) if text else 0,
+                text_words=text_words,
+                text_characters=text_chars,
             )
 
         usage_metrics: dict[str, int] = cast("dict[str, int]", usage)
@@ -780,8 +775,8 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
             audio_tokens=(usage_metrics.get("prompt_tokens") or 0),
         ), UsageMetrics(
             text_tokens=(usage_metrics.get("completion_tokens") or 0),
-            text_words=len(text.split()) if text else 0,
-            text_characters=len(text) if text else 0,
+            text_words=text_words,
+            text_characters=text_chars,
         )
 
 
@@ -999,14 +994,22 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         return 0
 
     def extract_metrics(
-        self, usage: dict[str, int | dict[str, int]] | None, text: str
+        self, usage: dict[str, int | dict[str, int]] | None, text: str | None
     ) -> tuple[UsageMetrics, UsageMetrics]:
         # Responses API uses "input_tokens"/"output_tokens" in its usage
         # payload, unlike chat completions' "prompt_tokens"/"completion_tokens".
+        if text is None:
+            # text not applicable — exclude from aggregation
+            text_words = None
+            text_chars = None
+        else:
+            text_words = len(text.split())
+            text_chars = len(text)
+
         if not usage:
             return UsageMetrics(), UsageMetrics(
-                text_words=len(text.split()) if text else 0,
-                text_characters=len(text) if text else 0,
+                text_words=text_words,
+                text_characters=text_chars,
             )
 
         usage_metrics: dict[str, int] = cast("dict[str, int]", usage)
@@ -1015,8 +1018,8 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             text_tokens=usage_metrics.get("input_tokens", 0),
         ), UsageMetrics(
             text_tokens=usage_metrics.get("output_tokens", 0),
-            text_words=len(text.split()) if text else 0,
-            text_characters=len(text) if text else 0,
+            text_words=text_words,
+            text_characters=text_chars,
         )
 
     @staticmethod

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -390,8 +390,13 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
     Extends TextCompletionsResponseHandler to handle chat completion requests where
     generated text is nested within message objects in the choices array. Processes
-    both streaming and non-streaming chat completion responses.
+    both streaming and non-streaming chat completion responses, including tool call
+    responses where the model outputs ``tool_calls`` instead of text content.
     """
+
+    def __init__(self):
+        super().__init__()
+        self.streaming_tool_calls: dict[int, dict] = {}
 
     def _format_prompts(
         self, column_data: list[dict[str, Any]], column_type: str
@@ -520,6 +525,27 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         return arguments
 
+    @staticmethod
+    def _tool_calls_to_text(tool_calls: list[dict]) -> str:
+        """Serialize a ``tool_calls`` array to a JSON string."""
+        # orjson.dumps returns bytes; stdlib json.dumps returns str
+        raw = json.dumps(tool_calls)
+        return raw.decode("utf-8") if isinstance(raw, bytes) else raw
+
+    @staticmethod
+    def _add_tool_call_metrics(
+        output_metrics: UsageMetrics, tool_call_count: int
+    ) -> None:
+        """Tag output metrics with tool call info (subset of text metrics).
+
+        Sets ``tool_call_tokens`` equal to ``text_tokens`` (since the server
+        reports all completion tokens together) and records the number of
+        individual tool calls. These fields are additive metadata -- they do
+        not affect ``total_tokens``.
+        """
+        output_metrics.tool_call_tokens = output_metrics.text_tokens
+        output_metrics.tool_call_count = tool_call_count
+
     def compile_non_streaming(
         self,
         request: GenerationRequest,
@@ -530,7 +556,8 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         Process a complete chat completion response.
 
         Extracts content from the message object within choices, handling the nested
-        structure specific to chat completion endpoints.
+        structure specific to chat completion endpoints. When the model returns tool
+        calls instead of text content, the tool calls are serialized as JSON text.
 
         :param request: Original generation request
         :param response: Complete API response containing choices and usage data
@@ -538,8 +565,15 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         """
         choices, usage = self.extract_choices_and_usage(response)
         choice: dict[str, dict] = choices[0] if choices else {}
-        text = choice.get("message", {}).get("content", "")
+        message = choice.get("message", {})
+        text = message.get("content") or ""
+        # Tool call responses set content=null and put output in tool_calls
+        tool_calls = message.get("tool_calls") if not text else None
+        if tool_calls:
+            text = self._tool_calls_to_text(tool_calls)
         input_metrics, output_metrics = self.extract_metrics(usage, text)
+        if tool_calls:
+            self._add_tool_call_metrics(output_metrics, len(tool_calls))
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -555,7 +589,8 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         Process a single line from a chat completion streaming response.
 
         Handles the chat completion specific delta structure where content is nested
-        within delta objects in the streaming response chunks.
+        within delta objects in the streaming response chunks. Also accumulates
+        ``tool_calls`` deltas when the model streams function call output.
 
         :param line: Raw SSE line from the streaming response
         :return: 1 if content was extracted, 0 if line ignored, None if done
@@ -569,9 +604,32 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         updated = False
         choices, usage = self.extract_choices_and_usage(data)
         choice: dict[str, dict] = choices[0] if choices else {}
+        delta = choice.get("delta", {}) if choices else {}
 
-        if choices and (content := choice.get("delta", {}).get("content")):
+        if content := delta.get("content"):
             self.streaming_texts.append(content)
+            updated = True
+
+        # Tool call streaming sends incremental chunks via delta.tool_calls.
+        # Each chunk (tc_delta) carries an "index" identifying which tool call
+        # it belongs to (for parallel tool calls), plus partial fragments of
+        # function.name and function.arguments that must be concatenated across
+        # multiple SSE events to reconstruct the complete call.
+        for tc_delta in delta.get("tool_calls", []):
+            idx = tc_delta.get("index", 0)
+            if idx not in self.streaming_tool_calls:
+                # First chunk for this tool call: initialize with id and type
+                self.streaming_tool_calls[idx] = {
+                    "id": tc_delta.get("id", ""),
+                    "type": tc_delta.get("type", "function"),
+                    "function": {"name": "", "arguments": ""},
+                }
+            tc = self.streaming_tool_calls[idx]
+            fn_delta = tc_delta.get("function", {})
+            if fn_name := fn_delta.get("name"):
+                tc["function"]["name"] += fn_name
+            if fn_args := fn_delta.get("arguments"):
+                tc["function"]["arguments"] += fn_args
             updated = True
 
         if usage:
@@ -585,11 +643,23 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         """
         Compile accumulated streaming chat completion content into a final response.
 
+        When no text content was streamed but tool calls were accumulated, the tool
+        calls are serialized as JSON text.
+
         :param request: Original generation request
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
         text = "".join(self.streaming_texts)
+        has_tool_calls = not text and bool(self.streaming_tool_calls)
+        if has_tool_calls:
+            tool_calls_list = [
+                self.streaming_tool_calls[idx]
+                for idx in sorted(self.streaming_tool_calls)
+            ]
+            text = self._tool_calls_to_text(tool_calls_list)
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
+        if has_tool_calls:
+            self._add_tool_call_metrics(output_metrics, len(self.streaming_tool_calls))
 
         return GenerationResponse(
             request_id=request.request_id,

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -559,14 +559,12 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         if text is None and not raw_tool_calls:
             text = ""  # Edge case: null content and no tools
         input_metrics, output_metrics = self.extract_metrics(usage, text)
-        # Always record tool_call_count. Only set tool_call_tokens on tool-only
-        # turns (content null) where the full completion total is attributable to
-        # tool output; on mixed turns the API does not split completion_tokens
-        # between natural language text and tool JSON.
         if raw_tool_calls:
             output_metrics.tool_call_count = len(raw_tool_calls)
-            if text is None:
+            if text is None:  # tool-only turn
                 output_metrics.tool_call_tokens = output_metrics.text_tokens
+            else:  # mixed content + tool call turn
+                output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -629,12 +627,12 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         if text is None and not has_tool_calls:
             text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
-        # Same semantics as compile_non_streaming: always record count, only
-        # attribute tokens on tool-only turns.
         if has_tool_calls:
             output_metrics.tool_call_count = len(self.streaming_tool_call_indices)
-            if text is None:
+            if text is None:  # tool-only turn
                 output_metrics.tool_call_tokens = output_metrics.text_tokens
+            else:  # mixed content + tool call turn
+                output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -554,14 +554,10 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choices, usage = self.extract_choices_and_usage(response)
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
-        # Per spec, content is null when the model produces tool calls instead
-        # of text. text=None excludes text metrics; text="" means text metrics
-        # are 0 for the rare empty-content edge case.
         text = message.get("content")
-        # Per spec, tool_calls is present when content is null.
-        tool_calls = message.get("tool_calls") if text is None else None
+        tool_calls = message.get("tool_calls")
         if text is None and not tool_calls:
-            text = ""
+            text = ""  # Edge case
         input_metrics, output_metrics = self.extract_metrics(usage, text)
         if tool_calls:
             output_metrics.tool_call_tokens = output_metrics.text_tokens
@@ -602,10 +598,10 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.streaming_texts.append(content)
             updated = True
 
-        # tool_calls is absent from text-only deltas; empty default is
-        # spec-correct. Each entry carries a required "index" identifying the
-        # tool call; missing index raises KeyError → errored request.
+        # tool_calls is an optional field for when the server is requesting a tool
         for tc_delta in delta.get("tool_calls", []):
+            # Keep track of the index to properly count tool usage, since a tool call
+            # can be split into multiple chunks when streaming.
             self.streaming_tool_call_indices.add(tc_delta["index"])
             updated = True
 

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -559,13 +559,14 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         if text is None and not raw_tool_calls:
             text = ""  # Edge case: null content and no tools
         input_metrics, output_metrics = self.extract_metrics(usage, text)
-        # Assistant messages may include both content and tool_calls. Fill tool
-        # metrics whenever tools are present so benchmark tool-modality aggregates
-        # are populated. tool_call_tokens mirrors text_tokens (completion total),
-        # not a separate API breakdown between prose and tool JSON.
+        # Always record tool_call_count. Only set tool_call_tokens on tool-only
+        # turns (content null) where the full completion total is attributable to
+        # tool output; on mixed turns the API does not split completion_tokens
+        # between natural language text and tool JSON.
         if raw_tool_calls:
-            output_metrics.tool_call_tokens = output_metrics.text_tokens
             output_metrics.tool_call_count = len(raw_tool_calls)
+            if text is None:
+                output_metrics.tool_call_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -628,10 +629,12 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         if text is None and not has_tool_calls:
             text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
-        # Same semantics as compile_non_streaming: tool deltas may accompany content.
+        # Same semantics as compile_non_streaming: always record count, only
+        # attribute tokens on tool-only turns.
         if has_tool_calls:
-            output_metrics.tool_call_tokens = output_metrics.text_tokens
             output_metrics.tool_call_count = len(self.streaming_tool_call_indices)
+            if text is None:
+                output_metrics.tool_call_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -555,13 +555,17 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
         text = message.get("content")
-        tool_calls = message.get("tool_calls")
-        if text is None and not tool_calls:
-            text = ""  # Edge case
+        raw_tool_calls = message.get("tool_calls")
+        if text is None and not raw_tool_calls:
+            text = ""  # Edge case: null content and no tools
         input_metrics, output_metrics = self.extract_metrics(usage, text)
-        if tool_calls:
+        # Assistant messages may include both content and tool_calls. Fill tool
+        # metrics whenever tools are present so benchmark tool-modality aggregates
+        # are populated. tool_call_tokens mirrors text_tokens (completion total),
+        # not a separate API breakdown between prose and tool JSON.
+        if raw_tool_calls:
             output_metrics.tool_call_tokens = output_metrics.text_tokens
-            output_metrics.tool_call_count = len(tool_calls)
+            output_metrics.tool_call_count = len(raw_tool_calls)
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -620,10 +624,11 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
         text = "".join(self.streaming_texts) or None
-        has_tool_calls = text is None and bool(self.streaming_tool_call_indices)
+        has_tool_calls = bool(self.streaming_tool_call_indices)
         if text is None and not has_tool_calls:
             text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
+        # Same semantics as compile_non_streaming: tool deltas may accompany content.
         if has_tool_calls:
             output_metrics.tool_call_tokens = output_metrics.text_tokens
             output_metrics.tool_call_count = len(self.streaming_tool_call_indices)

--- a/src/guidellm/backends/vllm_python/vllm_response.py
+++ b/src/guidellm/backends/vllm_python/vllm_response.py
@@ -52,13 +52,25 @@ class VLLMResponseHandler:
 
     @staticmethod
     def _extract_metrics(
-        usage: dict[str, Any] | None, text: str
+        usage: dict[str, Any] | None, text: str | None
     ) -> tuple[UsageMetrics, UsageMetrics]:
-        """Build UsageMetrics from usage dict and text (word/char counts)."""
+        """Build UsageMetrics from usage dict and text (word/char counts).
+
+        text=None means text is not applicable (metrics will be None);
+        text="" means text was applicable but empty (metrics will be 0).
+        """
+        if text is None:
+            # text not applicable (e.g. tool-call-only) — exclude from aggregation
+            text_words = None
+            text_chars = None
+        else:
+            text_words = len(text.split())
+            text_chars = len(text)
+
         if not usage:
             return UsageMetrics(), UsageMetrics(
-                text_words=len(text.split()) if text else 0,
-                text_characters=len(text) if text else 0,
+                text_words=text_words,
+                text_characters=text_chars,
             )
 
         usage_metrics = cast("dict[str, int]", usage)
@@ -78,8 +90,8 @@ class VLLMResponseHandler:
         )
         output_metrics = UsageMetrics(
             text_tokens=usage_metrics.get("completion_tokens", 0),
-            text_words=len(text.split()) if text else 0,
-            text_characters=len(text) if text else 0,
+            text_words=text_words,
+            text_characters=text_chars,
             image_tokens=output_details.get("image_tokens"),
             video_tokens=output_details.get("video_tokens"),
             audio_tokens=output_details.get("audio_tokens"),

--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -224,6 +224,7 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
         self.print_image_table(report)
         self.print_video_table(report)
         self.print_audio_table(report)
+        self.print_tool_call_table(report)
         self.print_request_counts_table(report)
         self.print_request_latency_table(report)
         self.print_server_throughput_table(report)
@@ -356,6 +357,22 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
                 ("samples", "Samples"),
                 ("seconds", "Seconds"),
                 ("bytes", "Bytes"),
+            ],
+        )
+
+    def print_tool_call_table(self, report: GenerativeBenchmarksReport):
+        """
+        Print tool-call-specific metrics table if any tool call data exists.
+
+        :param report: The benchmark report containing tool call metrics
+        """
+        self._print_modality_table(
+            report=report,
+            modality="tool_call",
+            title="Tool Call Metrics Statistics (Completed Requests)",
+            metric_groups=[
+                ("tokens", "Tokens"),
+                ("count", "Count"),
             ],
         )
 
@@ -512,7 +529,7 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
     def _print_modality_table(
         self,
         report: GenerativeBenchmarksReport,
-        modality: Literal["text", "image", "video", "audio"],
+        modality: Literal["text", "image", "video", "audio", "tool_call"],
         title: str,
         metric_groups: list[tuple[str, str]],
     ):

--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -372,6 +372,7 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
             title="Tool Call Metrics Statistics (Completed Requests)",
             metric_groups=[
                 ("tokens", "Tokens"),
+                ("mixed_tokens", "Mixed Tokens"),
                 ("count", "Count"),
             ],
         )

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -56,6 +56,7 @@ MODALITY_METRICS: Annotated[
     ],
     "tool_call": [
         ("tokens", "Tokens"),
+        ("mixed_tokens", "Mixed Tokens"),
         ("count", "Count"),
     ],
 }

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -54,6 +54,10 @@ MODALITY_METRICS: Annotated[
         ("seconds", "Seconds"),
         ("bytes", "Bytes"),
     ],
+    "tool_call": [
+        ("tokens", "Tokens"),
+        ("count", "Count"),
+    ],
 }
 
 

--- a/src/guidellm/benchmark/schemas/generative/metrics.py
+++ b/src/guidellm/benchmark/schemas/generative/metrics.py
@@ -711,9 +711,7 @@ class GenerativeToolCallMetricsSummary(StandardBaseDict):
         description="Tool call token count metrics and distributions"
     )
     mixed_tokens: GenerativeMetricsSummary | None = Field(
-        description=(
-            "Mixed content + tool call token count metrics and distributions"
-        )
+        description="Mixed content + tool call token count metrics and distributions"
     )
     count: GenerativeMetricsSummary | None = Field(
         description="Tool call count metrics and distributions"

--- a/src/guidellm/benchmark/schemas/generative/metrics.py
+++ b/src/guidellm/benchmark/schemas/generative/metrics.py
@@ -696,14 +696,24 @@ class GenerativeToolCallMetricsSummary(StandardBaseDict):
     """
     Tool-call-specific metric summaries for generative benchmarks.
 
-    tool_call_tokens is only populated for tool-only turns (content null) where
-    the full completion total is attributable to tool output. tool_call_count is
-    populated for all turns that include tool calls, including mixed content +
-    tool turns. Neither is added to total_tokens.
+    tokens: populated for tool-only turns (content null) where the full
+    completion total is attributable to tool output. Subset of text_tokens.
+
+    mixed_tokens: populated for mixed turns (content + tool calls) where the
+    API does not split completion_tokens between natural language text and
+    tool JSON. Subset of text_tokens.
+
+    count: populated for all turns that include tool calls, regardless of
+    whether content is also present.
     """
 
     tokens: GenerativeMetricsSummary | None = Field(
         description="Tool call token count metrics and distributions"
+    )
+    mixed_tokens: GenerativeMetricsSummary | None = Field(
+        description=(
+            "Mixed content + tool call token count metrics and distributions"
+        )
     )
     count: GenerativeMetricsSummary | None = Field(
         description="Tool call count metrics and distributions"
@@ -727,6 +737,12 @@ class GenerativeToolCallMetricsSummary(StandardBaseDict):
         return GenerativeToolCallMetricsSummary(
             tokens=GenerativeMetricsSummary.compile(
                 property_name="tool_call_tokens",
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+            mixed_tokens=GenerativeMetricsSummary.compile(
+                property_name="mixed_content_tool_tokens",
                 successful=successful,
                 incomplete=incomplete,
                 errored=errored,

--- a/src/guidellm/benchmark/schemas/generative/metrics.py
+++ b/src/guidellm/benchmark/schemas/generative/metrics.py
@@ -32,6 +32,7 @@ __all__ = [
     "GenerativeMetrics",
     "GenerativeMetricsSummary",
     "GenerativeTextMetricsSummary",
+    "GenerativeToolCallMetricsSummary",
     "GenerativeVideoMetricsSummary",
     "SchedulerMetrics",
     "StatusTypes",
@@ -691,6 +692,53 @@ class GenerativeAudioMetricsSummary(StandardBaseDict):
         )
 
 
+class GenerativeToolCallMetricsSummary(StandardBaseDict):
+    """
+    Tool-call-specific metric summaries for generative benchmarks.
+
+    Tracks token and count metrics for tool call outputs. These are a subset
+    of text metrics (tool_call_tokens is a subset of text_tokens) and are only
+    populated for requests where the model produced tool calls.
+    """
+
+    tokens: GenerativeMetricsSummary | None = Field(
+        description="Tool call token count metrics and distributions"
+    )
+    count: GenerativeMetricsSummary | None = Field(
+        description="Tool call count metrics and distributions"
+    )
+
+    @classmethod
+    def compile(
+        cls,
+        successful: list[GenerativeRequestStats],
+        incomplete: list[GenerativeRequestStats],
+        errored: list[GenerativeRequestStats],
+    ) -> GenerativeToolCallMetricsSummary:
+        """
+        Compile tool call metrics summary from request statistics.
+
+        :param successful: Successfully completed request statistics
+        :param incomplete: Incomplete/cancelled request statistics
+        :param errored: Failed request statistics
+        :return: Compiled tool call metrics summary
+        """
+        return GenerativeToolCallMetricsSummary(
+            tokens=GenerativeMetricsSummary.compile(
+                property_name="tool_call_tokens",
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+            count=GenerativeMetricsSummary.compile(
+                property_name="tool_call_count",
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+        )
+
+
 class GenerativeMetrics(StandardBaseDict):
     """
     Comprehensive metrics for generative AI benchmarks.
@@ -769,6 +817,9 @@ class GenerativeMetrics(StandardBaseDict):
     )
     audio: GenerativeAudioMetricsSummary = Field(
         description="Audio-specific metrics for tokens, samples, duration, and bytes"
+    )
+    tool_call: GenerativeToolCallMetricsSummary = Field(
+        description="Tool call metrics for tokens and call counts"
     )
 
     @classmethod
@@ -922,6 +973,9 @@ class GenerativeMetrics(StandardBaseDict):
                 successful=successful, incomplete=incomplete, errored=errored
             ),
             audio=GenerativeAudioMetricsSummary.compile(
+                successful=successful, incomplete=incomplete, errored=errored
+            ),
+            tool_call=GenerativeToolCallMetricsSummary.compile(
                 successful=successful, incomplete=incomplete, errored=errored
             ),
         )

--- a/src/guidellm/benchmark/schemas/generative/metrics.py
+++ b/src/guidellm/benchmark/schemas/generative/metrics.py
@@ -696,9 +696,10 @@ class GenerativeToolCallMetricsSummary(StandardBaseDict):
     """
     Tool-call-specific metric summaries for generative benchmarks.
 
-    Tracks token and count metrics for tool call outputs. These are a subset
-    of text metrics (tool_call_tokens is a subset of text_tokens) and are only
-    populated for requests where the model produced tool calls.
+    tool_call_tokens is only populated for tool-only turns (content null) where
+    the full completion total is attributable to tool output. tool_call_count is
+    populated for all turns that include tool calls, including mixed content +
+    tool turns. Neither is added to total_tokens.
     """
 
     tokens: GenerativeMetricsSummary | None = Field(

--- a/src/guidellm/mock_server/models.py
+++ b/src/guidellm/mock_server/models.py
@@ -146,6 +146,16 @@ class ChatCompletionsRequest(BaseModel):
     user: str | None = Field(
         default=None, description="User identifier for tracking and abuse monitoring"
     )
+    tools: list[dict[str, Any]] | None = Field(
+        default=None, description="Tool definitions for function calling"
+    )
+    tool_choice: str | dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Controls tool selection: 'auto', 'required', 'none', "
+            "or a specific function"
+        ),
+    )
 
     # vLLM extensions
     use_beam_search: bool | None = Field(

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -151,6 +151,17 @@ class UsageMetrics(StandardBaseDict):
         default=None, description="Number of audio bytes processed/generated."
     )
 
+    # Tool call stats (subset of text stats, not counted separately in total_tokens)
+    tool_call_tokens: int | None = Field(
+        default=None,
+        description=(
+            "Number of output tokens that were tool calls (subset of text_tokens)."
+        ),
+    )
+    tool_call_count: int | None = Field(
+        default=None, description="Number of tool calls generated."
+    )
+
     @computed_field  # type: ignore[misc]
     @property
     def total_tokens(self) -> int | None:

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -151,7 +151,7 @@ class UsageMetrics(StandardBaseDict):
         default=None, description="Number of audio bytes processed/generated."
     )
 
-    # Tool call stats (already included via text_tokens, not counted again in total_tokens)
+    # Tool call stats (already included in text_tokens)
     tool_call_tokens: int | None = Field(
         default=None,
         description=(

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -151,15 +151,22 @@ class UsageMetrics(StandardBaseDict):
         default=None, description="Number of audio bytes processed/generated."
     )
 
-    # Tool call stats (subset of text stats, not counted separately in total_tokens)
+    # Tool call stats (already included via text_tokens, not counted again in total_tokens)
     tool_call_tokens: int | None = Field(
         default=None,
         description=(
-            "Number of output tokens that were tool calls (subset of text_tokens)."
+            "Output completion token total for tool-only turns (content null). "
+            "Equal to text_tokens when the entire completion is tool output; "
+            "None on mixed content + tool turns because the API does not split "
+            "completion_tokens between natural language text and tool JSON."
         ),
     )
     tool_call_count: int | None = Field(
-        default=None, description="Number of tool calls generated."
+        default=None,
+        description=(
+            "Number of tool calls generated. Set whenever the response includes "
+            "tool calls, regardless of whether content is also present."
+        ),
     )
 
     @computed_field  # type: ignore[misc]

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -151,14 +151,23 @@ class UsageMetrics(StandardBaseDict):
         default=None, description="Number of audio bytes processed/generated."
     )
 
-    # Tool call stats (already included in text_tokens)
+    # Tool call stats (subset of text_tokens)
     tool_call_tokens: int | None = Field(
         default=None,
         description=(
             "Output completion token total for tool-only turns (content null). "
             "Equal to text_tokens when the entire completion is tool output; "
-            "None on mixed content + tool turns because the API does not split "
-            "completion_tokens between natural language text and tool JSON."
+            "None on mixed or text-only turns. Subset of text_tokens. "
+            "See mixed_content_tool_tokens for the mixed case."
+        ),
+    )
+    mixed_content_tool_tokens: int | None = Field(
+        default=None,
+        description=(
+            "Output completion token total for mixed content + tool call turns. "
+            "Equal to text_tokens when both natural language text and tool calls "
+            "are present; None on text-only or tool-only turns. Subset of "
+            "text_tokens."
         ),
     )
     tool_call_count: int | None = Field(

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -976,7 +976,7 @@ class TestChatCompletionsRequestHandler:
         """
         Test compile_non_streaming with both content and tool_calls. Text comes from
         content; tool_call_count is set but tool_call_tokens is None because the API
-        completion total includes both natural language text and tool output (no split available).
+        completion total includes both natural language text and tool output.
 
         ## WRITTEN BY AI ##
         """
@@ -1182,7 +1182,7 @@ class TestChatCompletionsRequestHandler:
         """
         Test streaming when both content and tool_calls deltas appear: final text
         is concatenated content; tool_call_count is set but tool_call_tokens is None
-        because the API completion total includes both natural language text and tool output.
+        because the API completion total includes both text and tool output.
 
         ## WRITTEN BY AI ##
         """

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -6,6 +6,8 @@ Unit tests for OpenAI request handlers.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from guidellm.backends.openai.request_handlers import (
@@ -925,6 +927,343 @@ class TestChatCompletionsRequestHandler:
         assert response.text == expected_text
         assert response.input_metrics.text_tokens == expected_input_tokens
         assert response.output_metrics.text_tokens == expected_output_tokens
+
+    # Tool call response handling tests
+
+    @pytest.mark.sanity
+    def test_non_streaming_tool_calls(self, valid_instances, generation_request):
+        """
+        Test compile_non_streaming extracts tool_calls when content is null.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        tool_calls = [
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "San Francisco, CA"}',
+                },
+            }
+        ]
+        response = {
+            "id": "chatcmpl-xyz",
+            "choices": [
+                {
+                    "message": {"content": None, "tool_calls": tool_calls},
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 15},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert json.loads(result.text) == tool_calls
+        assert result.input_metrics.text_tokens == 10
+        assert result.output_metrics.text_tokens == 15
+        assert result.output_metrics.tool_call_tokens == 15
+        assert result.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_non_streaming_tool_calls_content_preferred(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming prefers content over tool_calls when both present.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "I will call the function.",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "fn",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text == "I will call the function."
+        assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.tool_call_count is None
+
+    @pytest.mark.sanity
+    def test_non_streaming_multiple_tool_calls(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming with multiple parallel tool calls.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "SF"}',
+                },
+            },
+            {
+                "id": "call_2",
+                "type": "function",
+                "function": {
+                    "name": "get_time",
+                    "arguments": '{"timezone": "PST"}',
+                },
+            },
+        ]
+        response = {
+            "choices": [
+                {
+                    "message": {"content": None, "tool_calls": tool_calls},
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 20},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        parsed = json.loads(result.text)
+        assert len(parsed) == 2
+        assert parsed[0]["function"]["name"] == "get_weather"
+        assert parsed[1]["function"]["name"] == "get_time"
+        assert result.output_metrics.text_tokens == 20
+        assert result.output_metrics.tool_call_tokens == 20
+        assert result.output_metrics.tool_call_count == 2
+
+    @pytest.mark.sanity
+    def test_non_streaming_no_tool_calls_unchanged(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming with normal text response is unchanged.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "choices": [{"message": {"content": "Hello!"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text == "Hello!"
+        assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.tool_call_count is None
+
+    @pytest.mark.sanity
+    def test_streaming_tool_calls(self, valid_instances, generation_request):
+        """
+        Test streaming accumulates tool_calls deltas and serializes them.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            (
+                'data: {"id": "chatcmpl-1", "choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "id": "call_abc", "type": "function", '
+                '"function": {"name": "get_weather", "arguments": ""}}]}}], '
+                '"usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "function": {"arguments": "{\\"loc"}}]}}], '
+                '"usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "function": {"arguments": "ation\\": \\"SF\\"}"}}]}}], '
+                '"usage": {"prompt_tokens": 10, "completion_tokens": 12}}'
+            ),
+            "data: [DONE]",
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        parsed = json.loads(response.text)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == "call_abc"
+        assert parsed[0]["function"]["name"] == "get_weather"
+        assert parsed[0]["function"]["arguments"] == '{"location": "SF"}'
+        assert response.input_metrics.text_tokens == 10
+        assert response.output_metrics.text_tokens == 12
+        assert response.output_metrics.tool_call_tokens == 12
+        assert response.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_streaming_multiple_tool_calls(self, valid_instances, generation_request):
+        """
+        Test streaming with multiple parallel tool calls on different indices.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            (
+                'data: {"id": "chatcmpl-2", "choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "id": "call_1", "type": "function", '
+                '"function": {"name": "fn_a", "arguments": ""}}]}}], "usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 1, "id": "call_2", "type": "function", '
+                '"function": {"name": "fn_b", "arguments": ""}}]}}], "usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "function": {"arguments": "{\\"x\\": 1}"}}]}}], '
+                '"usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 1, "function": {"arguments": "{\\"y\\": 2}"}}]}}], '
+                '"usage": {"prompt_tokens": 8, "completion_tokens": 18}}'
+            ),
+            "data: [DONE]",
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        parsed = json.loads(response.text)
+        assert len(parsed) == 2
+        assert parsed[0]["function"]["name"] == "fn_a"
+        assert parsed[0]["function"]["arguments"] == '{"x": 1}'
+        assert parsed[1]["function"]["name"] == "fn_b"
+        assert parsed[1]["function"]["arguments"] == '{"y": 2}'
+        assert response.output_metrics.tool_call_tokens == 18
+        assert response.output_metrics.tool_call_count == 2
+
+    @pytest.mark.sanity
+    def test_streaming_text_preferred_over_tool_calls(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test that streaming text content is used when both text and tool_calls
+        are present (text takes precedence).
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            (
+                'data: {"id": "chatcmpl-3", "choices": [{"delta": '
+                '{"content": "Some text"}}], "usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"tool_calls": '
+                '[{"index": 0, "id": "call_x", "type": "function", '
+                '"function": {"name": "fn", "arguments": "{}"}}]}}], "usage": {}}'
+            ),
+            "data: [DONE]",
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text == "Some text"
+        assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.tool_call_count is None
+
+    @pytest.mark.sanity
+    def test_streaming_no_tool_calls_unchanged(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test that normal text streaming is unaffected by tool call support.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            (
+                'data: {"id": "chatcmpl-4", '
+                '"choices": [{"delta": {"content": "Hi"}}], '
+                '"usage": {}}'
+            ),
+            (
+                'data: {"choices": [{"delta": {"content": " there"}}], '
+                '"usage": {"prompt_tokens": 3, "completion_tokens": 2}}'
+            ),
+            "data: [DONE]",
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text == "Hi there"
+        assert response.input_metrics.text_tokens == 3
+        assert response.output_metrics.text_tokens == 2
+        assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.tool_call_count is None
+
+    @pytest.mark.smoke
+    def test_initialization_has_streaming_tool_calls(self, valid_instances):
+        """
+        Test ChatCompletionsRequestHandler initializes streaming_tool_calls.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        assert hasattr(instance, "streaming_tool_calls")
+        assert instance.streaming_tool_calls == {}
 
 
 class TestAudioRequestHandler:

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -974,7 +974,9 @@ class TestChatCompletionsRequestHandler:
         self, valid_instances, generation_request
     ):
         """
-        Test compile_non_streaming prefers content over tool_calls when both present.
+        Test compile_non_streaming with both content and tool_calls (valid assistant
+        message). Text comes from content; tool metrics mirror completion tokens
+        for benchmark tool-modality aggregation.
 
         ## WRITTEN BY AI ##
         """
@@ -1006,8 +1008,8 @@ class TestChatCompletionsRequestHandler:
         result = instance.compile_non_streaming(generation_request, arguments, response)
 
         assert result.text == "I will call the function."
-        assert result.output_metrics.tool_call_tokens is None
-        assert result.output_metrics.tool_call_count is None
+        assert result.output_metrics.tool_call_tokens == 8
+        assert result.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
     def test_non_streaming_multiple_tool_calls(
@@ -1178,8 +1180,9 @@ class TestChatCompletionsRequestHandler:
         self, valid_instances, generation_request
     ):
         """
-        Test that streaming text content is used when both text and tool_calls
-        are present (text takes precedence).
+        Test streaming when both content and tool_calls deltas appear: final text
+        is concatenated content; tool metrics mirror completion tokens for
+        benchmark tool-modality aggregation.
 
         ## WRITTEN BY AI ##
         """
@@ -1194,7 +1197,8 @@ class TestChatCompletionsRequestHandler:
             (
                 'data: {"choices": [{"delta": {"tool_calls": '
                 '[{"index": 0, "id": "call_x", "type": "function", '
-                '"function": {"name": "fn", "arguments": "{}"}}]}}], "usage": {}}'
+                '"function": {"name": "fn", "arguments": "{}"}}]}}], '
+                '"usage": {"prompt_tokens": 2, "completion_tokens": 8}}'
             ),
             "data: [DONE]",
         ]
@@ -1207,8 +1211,8 @@ class TestChatCompletionsRequestHandler:
         response = instance.compile_streaming(generation_request, arguments)
 
         assert response.text == "Some text"
-        assert response.output_metrics.tool_call_tokens is None
-        assert response.output_metrics.tool_call_count is None
+        assert response.output_metrics.tool_call_tokens == 8
+        assert response.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
     def test_streaming_no_tool_calls_unchanged(

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -1249,15 +1249,15 @@ class TestChatCompletionsRequestHandler:
         assert response.output_metrics.tool_call_count is None
 
     @pytest.mark.smoke
-    def test_initialization_has_streaming_tool_calls(self, valid_instances):
+    def test_initialization_has_streaming_tool_call_indices(self, valid_instances):
         """
-        Test ChatCompletionsRequestHandler initializes streaming_tool_calls.
+        Test ChatCompletionsRequestHandler initializes streaming_tool_call_indices.
 
         ## WRITTEN BY AI ##
         """
         instance = valid_instances
-        assert hasattr(instance, "streaming_tool_calls")
-        assert instance.streaming_tool_calls == {}
+        assert hasattr(instance, "streaming_tool_call_indices")
+        assert instance.streaming_tool_call_indices == set()
 
 
 class TestAudioRequestHandler:

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -967,6 +967,7 @@ class TestChatCompletionsRequestHandler:
         assert result.output_metrics.text_words is None
         assert result.output_metrics.text_characters is None
         assert result.output_metrics.tool_call_tokens == 15
+        assert result.output_metrics.mixed_content_tool_tokens is None
         assert result.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
@@ -975,8 +976,9 @@ class TestChatCompletionsRequestHandler:
     ):
         """
         Test compile_non_streaming with both content and tool_calls. Text comes from
-        content; tool_call_count is set but tool_call_tokens is None because the API
-        completion total includes both natural language text and tool output.
+        content; tool_call_count is set, tool_call_tokens is None, and
+        mixed_content_tool_tokens equals the completion total because the API does
+        not split completion_tokens between natural language text and tool JSON.
 
         ## WRITTEN BY AI ##
         """
@@ -1009,6 +1011,7 @@ class TestChatCompletionsRequestHandler:
 
         assert result.text == "I will call the function."
         assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.mixed_content_tool_tokens == 8
         assert result.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
@@ -1058,6 +1061,7 @@ class TestChatCompletionsRequestHandler:
         assert result.output_metrics.text_words is None
         assert result.output_metrics.text_characters is None
         assert result.output_metrics.tool_call_tokens == 20
+        assert result.output_metrics.mixed_content_tool_tokens is None
         assert result.output_metrics.tool_call_count == 2
 
     @pytest.mark.sanity
@@ -1081,6 +1085,7 @@ class TestChatCompletionsRequestHandler:
 
         assert result.text == "Hello!"
         assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.mixed_content_tool_tokens is None
         assert result.output_metrics.tool_call_count is None
 
     @pytest.mark.sanity
@@ -1126,6 +1131,7 @@ class TestChatCompletionsRequestHandler:
         assert response.output_metrics.text_words is None
         assert response.output_metrics.text_characters is None
         assert response.output_metrics.tool_call_tokens == 12
+        assert response.output_metrics.mixed_content_tool_tokens is None
         assert response.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
@@ -1173,6 +1179,7 @@ class TestChatCompletionsRequestHandler:
         assert response.output_metrics.text_words is None
         assert response.output_metrics.text_characters is None
         assert response.output_metrics.tool_call_tokens == 18
+        assert response.output_metrics.mixed_content_tool_tokens is None
         assert response.output_metrics.tool_call_count == 2
 
     @pytest.mark.sanity
@@ -1181,8 +1188,9 @@ class TestChatCompletionsRequestHandler:
     ):
         """
         Test streaming when both content and tool_calls deltas appear: final text
-        is concatenated content; tool_call_count is set but tool_call_tokens is None
-        because the API completion total includes both text and tool output.
+        is concatenated content; tool_call_count is set, tool_call_tokens is None,
+        and mixed_content_tool_tokens equals the completion total because the API
+        does not split completion_tokens between natural language text and tool JSON.
 
         ## WRITTEN BY AI ##
         """
@@ -1212,6 +1220,7 @@ class TestChatCompletionsRequestHandler:
 
         assert response.text == "Some text"
         assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.mixed_content_tool_tokens == 8
         assert response.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
@@ -1250,6 +1259,7 @@ class TestChatCompletionsRequestHandler:
         assert response.input_metrics.text_tokens == 3
         assert response.output_metrics.text_tokens == 2
         assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.mixed_content_tool_tokens is None
         assert response.output_metrics.tool_call_count is None
 
     @pytest.mark.smoke

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -974,9 +974,9 @@ class TestChatCompletionsRequestHandler:
         self, valid_instances, generation_request
     ):
         """
-        Test compile_non_streaming with both content and tool_calls (valid assistant
-        message). Text comes from content; tool metrics mirror completion tokens
-        for benchmark tool-modality aggregation.
+        Test compile_non_streaming with both content and tool_calls. Text comes from
+        content; tool_call_count is set but tool_call_tokens is None because the API
+        completion total includes both natural language text and tool output (no split available).
 
         ## WRITTEN BY AI ##
         """
@@ -1008,7 +1008,7 @@ class TestChatCompletionsRequestHandler:
         result = instance.compile_non_streaming(generation_request, arguments, response)
 
         assert result.text == "I will call the function."
-        assert result.output_metrics.tool_call_tokens == 8
+        assert result.output_metrics.tool_call_tokens is None
         assert result.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity
@@ -1181,8 +1181,8 @@ class TestChatCompletionsRequestHandler:
     ):
         """
         Test streaming when both content and tool_calls deltas appear: final text
-        is concatenated content; tool metrics mirror completion tokens for
-        benchmark tool-modality aggregation.
+        is concatenated content; tool_call_count is set but tool_call_tokens is None
+        because the API completion total includes both natural language text and tool output.
 
         ## WRITTEN BY AI ##
         """
@@ -1211,7 +1211,7 @@ class TestChatCompletionsRequestHandler:
         response = instance.compile_streaming(generation_request, arguments)
 
         assert response.text == "Some text"
-        assert response.output_metrics.tool_call_tokens == 8
+        assert response.output_metrics.tool_call_tokens is None
         assert response.output_metrics.tool_call_count == 1
 
     @pytest.mark.sanity

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -6,8 +6,6 @@ Unit tests for OpenAI request handlers.
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from guidellm.backends.openai.request_handlers import (
@@ -963,9 +961,11 @@ class TestChatCompletionsRequestHandler:
 
         result = instance.compile_non_streaming(generation_request, arguments, response)
 
-        assert json.loads(result.text) == tool_calls
+        assert result.text is None
         assert result.input_metrics.text_tokens == 10
         assert result.output_metrics.text_tokens == 15
+        assert result.output_metrics.text_words is None
+        assert result.output_metrics.text_characters is None
         assert result.output_metrics.tool_call_tokens == 15
         assert result.output_metrics.tool_call_count == 1
 
@@ -1051,11 +1051,10 @@ class TestChatCompletionsRequestHandler:
 
         result = instance.compile_non_streaming(generation_request, arguments, response)
 
-        parsed = json.loads(result.text)
-        assert len(parsed) == 2
-        assert parsed[0]["function"]["name"] == "get_weather"
-        assert parsed[1]["function"]["name"] == "get_time"
+        assert result.text is None
         assert result.output_metrics.text_tokens == 20
+        assert result.output_metrics.text_words is None
+        assert result.output_metrics.text_characters is None
         assert result.output_metrics.tool_call_tokens == 20
         assert result.output_metrics.tool_call_count == 2
 
@@ -1085,7 +1084,7 @@ class TestChatCompletionsRequestHandler:
     @pytest.mark.sanity
     def test_streaming_tool_calls(self, valid_instances, generation_request):
         """
-        Test streaming accumulates tool_calls deltas and serializes them.
+        Test streaming accumulates tool_calls deltas and sets tool call metrics.
 
         ## WRITTEN BY AI ##
         """
@@ -1119,13 +1118,11 @@ class TestChatCompletionsRequestHandler:
 
         response = instance.compile_streaming(generation_request, arguments)
 
-        parsed = json.loads(response.text)
-        assert len(parsed) == 1
-        assert parsed[0]["id"] == "call_abc"
-        assert parsed[0]["function"]["name"] == "get_weather"
-        assert parsed[0]["function"]["arguments"] == '{"location": "SF"}'
+        assert response.text is None
         assert response.input_metrics.text_tokens == 10
         assert response.output_metrics.text_tokens == 12
+        assert response.output_metrics.text_words is None
+        assert response.output_metrics.text_characters is None
         assert response.output_metrics.tool_call_tokens == 12
         assert response.output_metrics.tool_call_count == 1
 
@@ -1170,12 +1167,9 @@ class TestChatCompletionsRequestHandler:
 
         response = instance.compile_streaming(generation_request, arguments)
 
-        parsed = json.loads(response.text)
-        assert len(parsed) == 2
-        assert parsed[0]["function"]["name"] == "fn_a"
-        assert parsed[0]["function"]["arguments"] == '{"x": 1}'
-        assert parsed[1]["function"]["name"] == "fn_b"
-        assert parsed[1]["function"]["arguments"] == '{"y": 2}'
+        assert response.text is None
+        assert response.output_metrics.text_words is None
+        assert response.output_metrics.text_characters is None
         assert response.output_metrics.tool_call_tokens == 18
         assert response.output_metrics.tool_call_count == 2
 

--- a/tests/unit/schemas/test_request.py
+++ b/tests/unit/schemas/test_request.py
@@ -574,6 +574,24 @@ class TestUsageMetrics:
         assert metrics.text_words == expected_words
 
     @pytest.mark.sanity
+    def test_total_tokens_excludes_tool_call_tokens(self):
+        """
+        Verify tool_call_tokens is not double-counted in total_tokens.
+
+        tool_call_tokens is a subset of text_tokens, so total_tokens should
+        only reflect text_tokens (and other modality tokens), not add
+        tool_call_tokens on top.
+
+        ## WRITTEN BY AI ##
+        """
+        metrics = UsageMetrics(
+            text_tokens=50,
+            tool_call_tokens=50,
+            tool_call_count=2,
+        )
+        assert metrics.total_tokens == 50
+
+    @pytest.mark.sanity
     def test_marshalling(self, valid_instances):
         """Test UsageMetrics serialization and deserialization."""
         instance, constructor_args = valid_instances


### PR DESCRIPTION
## Summary

This is a first step towards getting tool calling working.

## Details

- Allows counting and reporting of tool calls and their associated tokens.
- Supports the chat completions API.
- Displays the tool metrics in the CSV output and the console output, in addition to the JSON/YAML output, which includes everything.

## Test Plan

- Start vLLM with tool calling enabled:
  ```
  --enable-auto-tool-choice --tool-call-parser hermes
  ```
- Run a benchmark with backend args set such that they specify a tool and request a tool call.
   Example:
   ```
   guidellm benchmark   --target http://localhost:8000   --model "Qwen/Qwen3-0.6B" --data mixed_tool_call_prompts.jsonl --profile constant  --rate 1   --max-requests 5 --backend-kwargs '{
    "extras": {
      "body": {
        "tools": [
          {
            "type": "function",
            "function": {
              "name": "get_weather",
              "description": "Get the current weather for a location",
              "parameters": {
                "type": "object",
                "properties": {
                  "location": {
                    "type": "string",
                    "description": "City and state, e.g. San Francisco, CA"
                  }
                },
                "required": ["location"]
              }
            }
          }
        ],
        "tool_choice": "required"
      }
    }
  }'
   ```

## Related Issues

- Works towards #416 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
