### PR TITLE
Fix long import times due to processing all pydantic subclasses

### DIFF
--- a/src/guidellm/schemas/base.py
+++ b/src/guidellm/schemas/base.py
@@ -87,7 +87,10 @@ class ReloadableBaseModel(BaseModel):
         subclasses, so third-party Pydantic models loaded in the same process
         are not visited.
         """
-        potential_parents: set[type[BaseModel]] = {ReloadableBaseModel, StandardBaseModel}
+        potential_parents: set[type[BaseModel]] = {
+            ReloadableBaseModel,
+            StandardBaseModel
+        }
         stack: list[type[BaseModel]] = list(potential_parents)
 
         while stack:

--- a/src/guidellm/schemas/base.py
+++ b/src/guidellm/schemas/base.py
@@ -89,7 +89,7 @@ class ReloadableBaseModel(BaseModel):
         """
         potential_parents: set[type[BaseModel]] = {
             ReloadableBaseModel,
-            StandardBaseModel
+            StandardBaseModel,
         }
         stack: list[type[BaseModel]] = list(potential_parents)
 

--- a/src/guidellm/schemas/base.py
+++ b/src/guidellm/schemas/base.py
@@ -79,14 +79,16 @@ class ReloadableBaseModel(BaseModel):
     @classmethod
     def reload_parent_schemas(cls):
         """
-        Recursively reload schemas for all parent Pydantic models.
+        Recursively reload schemas for all Pydantic models that reference this
+        class in their field annotations.
 
-        Traverses the inheritance hierarchy to find all parent classes that
-        are Pydantic models and triggers schema rebuilding on each to ensure
-        that any changes in child models are reflected in parent schemas.
+        Walks the subclass trees of guidellm's own model roots
+        (ReloadableBaseModel and StandardBaseModel) rather than all BaseModel
+        subclasses, so third-party Pydantic models loaded in the same process
+        are not visited.
         """
-        potential_parents: set[type[BaseModel]] = {BaseModel}
-        stack: list[type[BaseModel]] = [BaseModel]
+        potential_parents: set[type[BaseModel]] = {ReloadableBaseModel, StandardBaseModel}
+        stack: list[type[BaseModel]] = list(potential_parents)
 
         while stack:
             current = stack.pop()


### PR DESCRIPTION
## Summary

Other libraries that use pydantic could end up being processed by GuideLLM, significantly increasing the number of classes processed, noticeably increasing import times for GuideLLM.

Also, in my testing, it makes it so the startup times are less than half of what they were before.

## Details

- Rather than just searching every Pydantic subclass, it only searches sub-classes that we created. So no other libraries will add to the processing burden.
- On my mac, within the Python virtual environment, this change resulted in a change from around 27.5 seconds before the benchmark starts to 6.5 seconds. This is due to how long it spent processing the classes on my local env. It has been super slow since this was originally added in the refactor.
- The only classes that use this functionality are `BenchmarkConfig`, `BenchmarkGenerativeTextArgs`, and `Profile`,

## Test Plan

- Run benchmarks as normal, and confirm that the options that depend on registry mix in work.

## Related Issues

- Resolves #688 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
