### PR TITLE
Apply tool calling stats to the responses API

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -898,7 +898,11 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         response: dict,
     ) -> GenerationResponse:
         text = self._extract_output_text(response)
-        tool_call_count = self._count_function_calls(response)
+        tool_call_count = sum(
+            1
+            for item in response.get("output", [])
+            if item.get("type") == "function_call"
+        )
         if text is None and not tool_call_count:
             text = ""
         usage = response.get("usage", {})
@@ -1039,7 +1043,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
     def _extract_output_text(response: dict) -> str | None:
         """Extract generated text from a Responses API response object.
 
-        Returns ``None`` when no message/output_text items exist (e.g. tool-call-
+        :returns: ``None`` when no message/output_text items exist (e.g. tool-call-
         only responses), so callers can distinguish "no text" from "empty text".
         """
         texts: list[str] = []
@@ -1050,15 +1054,6 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                 if part.get("type") == "output_text":
                     texts.append(part.get("text", ""))
         return "".join(texts) if texts else None
-
-    @staticmethod
-    def _count_function_calls(response: dict) -> int:
-        """Count ``function_call`` output items in a Responses API response."""
-        return sum(
-            1
-            for item in response.get("output", [])
-            if item.get("type") == "function_call"
-        )
 
 
 @OpenAIRequestHandlerFactory.register("/pooling")

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -782,6 +782,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         self.streaming_texts: list[str] = []
         self.streaming_usage: dict[str, int | dict[str, int]] | None = None
         self.streaming_response_id: str | None = None
+        self.streaming_tool_call_indices: set[int] = set()
 
     def _format_prompts(
         self, column_data: list, column_type: str
@@ -897,8 +898,17 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         response: dict,
     ) -> GenerationResponse:
         text = self._extract_output_text(response)
+        tool_call_count = self._count_function_calls(response)
+        if text is None and not tool_call_count:
+            text = ""
         usage = response.get("usage", {})
         input_metrics, output_metrics = self.extract_metrics(usage, text)
+        if tool_call_count:
+            output_metrics.tool_call_count = tool_call_count
+            if text is None:  # tool-only turn
+                output_metrics.tool_call_tokens = output_metrics.text_tokens
+            else:  # mixed content + tool call turn
+                output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -912,8 +922,17 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
     def compile_streaming(
         self, request: GenerationRequest, arguments: GenerationRequestArguments
     ) -> GenerationResponse:
-        text = "".join(self.streaming_texts)
+        text = "".join(self.streaming_texts) or None
+        has_tool_calls = bool(self.streaming_tool_call_indices)
+        if text is None and not has_tool_calls:
+            text = ""
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
+        if has_tool_calls:
+            output_metrics.tool_call_count = len(self.streaming_tool_call_indices)
+            if text is None:  # tool-only turn
+                output_metrics.tool_call_tokens = output_metrics.text_tokens
+            else:  # mixed content + tool call turn
+                output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
         return GenerationResponse(
             request_id=request.request_id,
@@ -950,7 +969,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
 
         if "id" in data and self.streaming_response_id is None:
             resp = data.get("response", {})
-            if isinstance(resp, dict) and "id" in resp:
+            if "id" in resp:
                 self.streaming_response_id = resp["id"]
 
         if event_type == "response.output_text.delta":
@@ -959,6 +978,13 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                 self.streaming_texts.append(delta)
                 return 1
             return 0
+
+        if (
+            event_type == "response.output_item.added"
+            and data.get("item", {}).get("type") == "function_call"
+        ):
+            self.streaming_tool_call_indices.add(data["output_index"])
+            return 1
 
         if event_type in (
             "response.completed",
@@ -970,13 +996,12 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             # by some providers instead. Each carries a final response object
             # with optional usage data. Returning None signals the streaming
             # loop in http.py to break out of the stream.
-            resp = data.get("response", {})
-            if isinstance(resp, dict):
-                usage = resp.get("usage")
-                if usage:
-                    self.streaming_usage = usage
-                if self.streaming_response_id is None and "id" in resp:
-                    self.streaming_response_id = resp["id"]
+            resp = data.get("response") or {}
+            usage = resp.get("usage")
+            if usage:
+                self.streaming_usage = usage
+            if self.streaming_response_id is None and "id" in resp:
+                self.streaming_response_id = resp["id"]
             return None
 
         return 0
@@ -1011,8 +1036,12 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         )
 
     @staticmethod
-    def _extract_output_text(response: dict) -> str:
-        """Extract generated text from a Responses API response object."""
+    def _extract_output_text(response: dict) -> str | None:
+        """Extract generated text from a Responses API response object.
+
+        Returns ``None`` when no message/output_text items exist (e.g. tool-call-
+        only responses), so callers can distinguish "no text" from "empty text".
+        """
         texts: list[str] = []
         for item in response.get("output", []):
             if item.get("type") != "message":
@@ -1020,7 +1049,16 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             for part in item.get("content", []):
                 if part.get("type") == "output_text":
                     texts.append(part.get("text", ""))
-        return "".join(texts)
+        return "".join(texts) if texts else None
+
+    @staticmethod
+    def _count_function_calls(response: dict) -> int:
+        """Count ``function_call`` output items in a Responses API response."""
+        return sum(
+            1
+            for item in response.get("output", [])
+            if item.get("type") == "function_call"
+        )
 
 
 @OpenAIRequestHandlerFactory.register("/pooling")

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2569,6 +2569,355 @@ class TestResponsesRequestHandler:
         assert input_items[1]["content"] == "4"
         assert input_items[2]["role"] == "user"
 
+    # Tool call response handling tests
+
+    @pytest.mark.sanity
+    def test_non_streaming_tool_calls(self, valid_instances, generation_request):
+        """
+        Test compile_non_streaming extracts function_call items when no text present.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "id": "resp_tc1",
+            "output": [
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "arguments": '{"location": "SF"}',
+                    "call_id": "call_abc123",
+                }
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 15},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text is None
+        assert result.input_metrics.text_tokens == 10
+        assert result.output_metrics.text_tokens == 15
+        assert result.output_metrics.text_words is None
+        assert result.output_metrics.text_characters is None
+        assert result.output_metrics.tool_call_tokens == 15
+        assert result.output_metrics.mixed_content_tool_tokens is None
+        assert result.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_non_streaming_tool_calls_content_preferred(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming with both message and function_call output items.
+        Text comes from message content; tool_call_count is set, tool_call_tokens is
+        None, and mixed_content_tool_tokens equals the completion total because the
+        API does not split completion_tokens between natural language text and tool
+        JSON.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "id": "resp_tc2",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "I will call the function."}
+                    ],
+                },
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "arguments": '{"location": "SF"}',
+                    "call_id": "call_1",
+                },
+            ],
+            "usage": {"input_tokens": 5, "output_tokens": 8},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text == "I will call the function."
+        assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.mixed_content_tool_tokens == 8
+        assert result.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_non_streaming_multiple_tool_calls(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming counts multiple function_call items.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "id": "resp_tc3",
+            "output": [
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "arguments": '{"location": "SF"}',
+                    "call_id": "call_1",
+                },
+                {
+                    "type": "function_call",
+                    "name": "get_time",
+                    "arguments": '{"timezone": "PST"}',
+                    "call_id": "call_2",
+                },
+            ],
+            "usage": {"input_tokens": 12, "output_tokens": 20},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text is None
+        assert result.output_metrics.text_tokens == 20
+        assert result.output_metrics.text_words is None
+        assert result.output_metrics.text_characters is None
+        assert result.output_metrics.tool_call_tokens == 20
+        assert result.output_metrics.mixed_content_tool_tokens is None
+        assert result.output_metrics.tool_call_count == 2
+
+    @pytest.mark.sanity
+    def test_non_streaming_no_tool_calls_unchanged(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test compile_non_streaming leaves tool_call fields None for normal text.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        response = {
+            "id": "resp_tc4",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Hello!"}],
+                }
+            ],
+            "usage": {"input_tokens": 3, "output_tokens": 2},
+        }
+
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+
+        assert result.text == "Hello!"
+        assert result.output_metrics.tool_call_tokens is None
+        assert result.output_metrics.mixed_content_tool_tokens is None
+        assert result.output_metrics.tool_call_count is None
+
+    @pytest.mark.sanity
+    def test_streaming_tool_calls(self, valid_instances, generation_request):
+        """
+        Test streaming accumulates function_call output items and sets metrics.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            "event: response.output_item.added",
+            (
+                'data: {"type":"response.output_item.added",'
+                '"output_index":0,'
+                '"item":{"type":"function_call","name":"get_weather",'
+                '"call_id":"call_abc","arguments":""}}'
+            ),
+            "",
+            "event: response.function_call_arguments.delta",
+            (
+                'data: {"type":"response.function_call_arguments.delta",'
+                '"output_index":0,"delta":"{\\"loc\\""}'
+            ),
+            "",
+            "event: response.function_call_arguments.done",
+            (
+                'data: {"type":"response.function_call_arguments.done",'
+                '"output_index":0,"arguments":"{\\"loc\\":\\"SF\\"}"}'
+            ),
+            "",
+            "event: response.completed",
+            (
+                'data: {"type":"response.completed",'
+                '"response":{"id":"resp_s1",'
+                '"usage":{"input_tokens":10,"output_tokens":12}}}'
+            ),
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text is None
+        assert response.output_metrics.text_tokens == 12
+        assert response.output_metrics.text_words is None
+        assert response.output_metrics.text_characters is None
+        assert response.output_metrics.tool_call_tokens == 12
+        assert response.output_metrics.mixed_content_tool_tokens is None
+        assert response.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_streaming_multiple_tool_calls(self, valid_instances, generation_request):
+        """
+        Test streaming with multiple parallel function calls on different indices.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            "event: response.output_item.added",
+            (
+                'data: {"type":"response.output_item.added",'
+                '"output_index":0,'
+                '"item":{"type":"function_call","name":"fn_a",'
+                '"call_id":"call_1","arguments":""}}'
+            ),
+            "",
+            "event: response.output_item.added",
+            (
+                'data: {"type":"response.output_item.added",'
+                '"output_index":1,'
+                '"item":{"type":"function_call","name":"fn_b",'
+                '"call_id":"call_2","arguments":""}}'
+            ),
+            "",
+            "event: response.completed",
+            (
+                'data: {"type":"response.completed",'
+                '"response":{"id":"resp_s2",'
+                '"usage":{"input_tokens":8,"output_tokens":18}}}'
+            ),
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text is None
+        assert response.output_metrics.text_words is None
+        assert response.output_metrics.text_characters is None
+        assert response.output_metrics.tool_call_tokens == 18
+        assert response.output_metrics.mixed_content_tool_tokens is None
+        assert response.output_metrics.tool_call_count == 2
+
+    @pytest.mark.sanity
+    def test_streaming_text_preferred_over_tool_calls(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test streaming when both text deltas and function_call items appear: final
+        text is concatenated content; tool_call_count is set, tool_call_tokens is
+        None, and mixed_content_tool_tokens equals the completion total because the
+        API does not split completion_tokens between natural language text and tool
+        JSON.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            "event: response.output_text.delta",
+            ('data: {"type":"response.output_text.delta","delta":"Some text"}'),
+            "",
+            "event: response.output_item.added",
+            (
+                'data: {"type":"response.output_item.added",'
+                '"output_index":1,'
+                '"item":{"type":"function_call","name":"fn",'
+                '"call_id":"call_x","arguments":"{}"}}'
+            ),
+            "",
+            "event: response.completed",
+            (
+                'data: {"type":"response.completed",'
+                '"response":{"id":"resp_s3",'
+                '"usage":{"input_tokens":5,"output_tokens":4}}}'
+            ),
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text == "Some text"
+        assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.mixed_content_tool_tokens == 4
+        assert response.output_metrics.tool_call_count == 1
+
+    @pytest.mark.sanity
+    def test_streaming_no_tool_calls_unchanged(
+        self, valid_instances, generation_request
+    ):
+        """
+        Test normal streaming text response has no tool_call metrics.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            "event: response.output_text.delta",
+            ('data: {"type":"response.output_text.delta","delta":"Hi there"}'),
+            "",
+            "event: response.completed",
+            (
+                'data: {"type":"response.completed",'
+                '"response":{"id":"resp_s4",'
+                '"usage":{"input_tokens":3,"output_tokens":2}}}'
+            ),
+        ]
+
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+
+        assert response.text == "Hi there"
+        assert response.input_metrics.text_tokens == 3
+        assert response.output_metrics.text_tokens == 2
+        assert response.output_metrics.tool_call_tokens is None
+        assert response.output_metrics.mixed_content_tool_tokens is None
+        assert response.output_metrics.tool_call_count is None
+
+    @pytest.mark.smoke
+    def test_initialization_has_streaming_tool_call_indices(self, valid_instances):
+        """
+        Test ResponsesRequestHandler initializes streaming_tool_call_indices.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        assert hasattr(instance, "streaming_tool_call_indices")
+        assert instance.streaming_tool_call_indices == set()
+
 
 class TestPoolingRequestHandler:
     """Test cases for PoolingRequestHandler.


### PR DESCRIPTION
## Summary

This PR applies the same tool counting logic to the responses API.

## Details

- Counts tool-only or mixed responses.
- Is pretty simple.

## Test Plan

Start vLLM with tools enabled:
`--enable-auto-tool-choice --tool-call-parser hermes`

Run a benchmark:
  ```
  guidellm benchmark run   --target "http://localhost:8000"   --request-format /v1/responses   --data mixed_tool_call_prompts.jsonl   --data-column-mapper '{"text_column":"text"}'   --backend-kwargs '{"stream":false,"extras":{"body":{"tools":[{"type":"function","name":"get_weather","description":"Get current weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]},"strict":true}],"tool_choice":"auto"}}}'   --max-requests 5 --profile constant --rate 0.2
  ```

Here is mixed_tool_call_prompts.jsonl
```jsonl
{"prompt": "Use the get_weather function to check the weather in San Francisco."}
{"prompt": "Explain how photosynthesis works."}
{"prompt": "Call get_weather for Tokyo to get the forecast."}
{"prompt": "Write a haiku about mountains."}
{"prompt": "Please call the get_weather tool for London."}
{"prompt": "Summarize the history of the Roman Empire."}
```

The logic is different with tool call auto vs required. It appears that required typically results in tool call only responses.

## Related Issues

- Works towards #416

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
